### PR TITLE
feat(driver): bound static pools with start/end and a separate prefix

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -123,10 +123,12 @@ See [networking.md](networking.md) for how to build the node network itself.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `pve-cloudinit` | `false` | Push `ipconfig0` / `ciuser` / `sshkeys` to the cloned VM. **Required** for any data disk with a filesystem |
+| `pve-cloudinit` | `true` | Deprecated and always on. Cloud-init is the only channel for the SSH key, the static address and the DNS settings, so the driver enables it regardless |
 | `pve-ip-mode` | `dhcp` | `dhcp` or `static`. Static derives each machine's address from its VMID, so it requires `pve-vmid-range` |
-| `pve-ip-base` | — | First address of the static pool in CIDR form, e.g. `10.10.20.10/24`. The lowest VMID in the range gets this address; each later VMID gets the next |
-| `pve-gateway` | — | Default gateway for static addressing. Must be inside the subnet of `pve-ip-base` |
+| `pve-ip-start` | — | First address of the static pool, e.g. `192.168.15.150`. The lowest VMID in the range gets this address; each later VMID gets the next |
+| `pve-ip-end` | — | Last address of the pool, e.g. `192.168.15.159`. The pool size caps how many machines the machine pool can hold |
+| `pve-ip-prefix` | — | Subnet prefix length the machines get, e.g. `24`. **The netmask, not the pool size** — see below |
+| `pve-gateway` | — | Default gateway. May sit outside the pool, but must be inside the subnet `pve-ip-prefix` describes |
 | `pve-nameservers` | — | DNS servers, space- or comma-separated. Applies in both modes; empty keeps the DHCP-supplied resolver |
 | `pve-searchdomain` | — | DNS search domain, e.g. `cluster.lan`. Applies in both modes |
 | `pve-ciuser` | *(empty)* | Cloud-init user to create and install the keys for. Empty means "same as `pve-ssh-user`", which is nearly always what you want |
@@ -139,46 +141,68 @@ keys for `ciuser`, and that is the only account anything can subsequently log
 into. Leaving `pve-ciuser` empty derives it from `pve-ssh-user`, which is why the
 UI exposes a single **VM User** field.
 
+### The prefix is the netmask, not the pool size
+
+This is the one thing worth reading twice. The pool is bounded by
+`pve-ip-start` and `pve-ip-end`; `pve-ip-prefix` is the netmask the machines
+get — what they use to decide whether an address is reachable directly or has to
+go via the gateway.
+
+They are separate fields because folding them into a single CIDR invites writing
+`/28` to mean "16 addresses". That does not bound the pool: it narrows the
+subnet to `192.168.15.144–.159`, so a gateway at `192.168.15.1` is no longer
+on-link, the default route cannot be installed, and the node boots unable to
+reach anything.
+
+So set `pve-ip-prefix` to the prefix of the **real network** — usually the same
+`/24` your LAN uses — and bound the pool with start and end:
+
+```
+pve-ip-start  = 192.168.15.150
+pve-ip-end    = 192.168.15.159
+pve-ip-prefix = 24
+pve-gateway   = 192.168.15.1
+```
+
+The gateway sits outside `.150–.159`, which is expected and fine. What is
+rejected is a gateway outside the `/24`.
+
 ### How static addresses are allocated
 
 The driver is a separate process per machine with no shared state, so there is
 nothing to allocate against. The address is derived instead:
 
 ```
-address = pve-ip-base + (vmid - <low end of pve-vmid-range>)
+address = pve-ip-start + (vmid - <low end of pve-vmid-range>)
 ```
 
-With `pve-vmid-range 200-299` and `pve-ip-base 10.10.20.10/24`, VMID 200 gets
-`10.10.20.10`, VMID 201 gets `10.10.20.11`, and so on. Deleting a machine frees
-its VMID and therefore its address.
+With `pve-vmid-range 200-299` and the pool above, VMID 200 gets
+`192.168.15.150`, VMID 201 gets `.151`, and so on. Deleting a machine frees its
+VMID and therefore its address.
 
-**Give each pool its own `pve-ip-base`.** VMIDs are unique across the whole
-cluster — the driver picks one by scanning `/cluster/resources` — so two pools
-drawing from the *same* VMID range always get different VMIDs and therefore
-different addresses. That case is safe. The collision is the opposite one: two
-pools with **different** range minima but the **same** `pve-ip-base`. With
-`200-299` and `300-399` both based at `10.10.20.10/24`, VMID 200 and VMID 300
-both compute offset 0 and both claim `10.10.20.10`. So either give each pool a
-distinct base, or let pools share the range *and* the base.
+**Give each pool its own address range.** VMIDs are unique across the whole
+cluster — the driver picks one by scanning `/cluster/resources` — so two machine
+pools drawing from the *same* VMID range always get different VMIDs and
+therefore different addresses. That case is safe. The collision is the opposite
+one: two pools with **different** range minima but the **same** `pve-ip-start`.
+With `200-299` and `300-399` both starting at `192.168.15.150`, VMID 200 and
+VMID 300 both compute offset 0 and both claim `.150`.
 
-**The subnet caps the pool, not the VMID range.** VMIDs are handed out
-lowest-free-first, so machines fill the subnet upward from the base and the
-subnet only has to hold the machines that exist at once. A VMID range *wider*
-than the subnet is therefore normal and accepted — it just supplies ids. With
-`pve-ip-base 10.10.20.9/30` (a `/30` spans `.8`–`.11`, so `.9` and `.10` are
-usable) and `pve-vmid-range 200-299`, the pool holds **two** machines; the third
-fails with:
+**The pool caps the machine count, not the VMID range.** VMIDs are handed out
+lowest-free-first, so machines fill the pool from the start upward and it only
+has to hold the machines running at once. A VMID range *wider* than the pool is
+therefore normal — it just supplies ids. With the ten-address pool above and
+`pve-vmid-range 200-299`, the eleventh machine fails with:
 
 ```
-pve: static IP pool exhausted: --pve-ip-base 10.10.20.9/30 leaves room for
-2 machines from 10.10.20.9, and VMID 202 needs offset 2
+pve: static IP pool exhausted: 192.168.15.150-192.168.15.159 holds 10 machines,
+and VMID 210 needs slot 11; widen the pool or scale down
 ```
 
-Earlier versions demanded the subnet cover the *whole* VMID range, which forced
-a `/25` just to run three nodes with a 100-wide range. `PreCreateCheck` now only
-rejects a base that is unusable outright — the network or broadcast address, or
-one with no room left before the end of its subnet — and logs the real capacity
-when the VMID range exceeds it.
+`PreCreateCheck` rejects a pool whose ends fall in different subnets, one that
+includes the subnet's network or broadcast address, an end below the start, or a
+gateway outside the subnet. It logs the real capacity when the VMID range
+exceeds it.
 
 DNS (`pve-nameservers`, `pve-searchdomain`) requires `pve-cloudinit` in either
 mode, because PVE applies `nameserver`/`searchdomain` as cloud-init options and

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -223,21 +223,55 @@ separate process per machine with no shared state, so there is nothing to
 allocate against — the address is **derived** from the VMID:
 
 ```
-address = pve-ip-base + (vmid - <low end of pve-vmid-range>)
+address = pve-ip-start + (vmid - <low end of pve-vmid-range>)
 ```
 
-Worked example, with `pve-vmid-range 200-299`, `pve-ip-base 10.10.20.10/24` and
-`pve-gateway 10.10.20.1`:
+The pool is written as three fields: **start**, **end**, and the **subnet
+prefix** the machines get. Worked example, with `pve-vmid-range 200-299`:
+
+```
+pve-ip-start  = 192.168.15.150
+pve-ip-end    = 192.168.15.159
+pve-ip-prefix = 24
+pve-gateway   = 192.168.15.1
+```
 
 | VMID | Address |
 |---|---|
-| 200 | `10.10.20.10/24` |
-| 201 | `10.10.20.11/24` |
-| 202 | `10.10.20.12/24` |
-| 299 | `10.10.20.109/24` |
+| 200 | `192.168.15.150/24` |
+| 201 | `192.168.15.151/24` |
+| 209 | `192.168.15.159/24` |
+| 210 | pool exhausted |
 
 Deleting a machine frees its VMID and therefore its address; the next machine
 reclaims both.
+
+### The prefix is the netmask, not the pool size
+
+The most common mistake, and the reason these are three fields rather than one
+CIDR. The pool is bounded by **start** and **end**. The **prefix** is the
+netmask each machine gets — what it uses to decide whether an address is
+reachable directly or must go via the gateway.
+
+Writing `/28` to mean "16 addresses" does not bound the pool. It narrows the
+subnet to `192.168.15.144`–`.159`, so a gateway at `192.168.15.1` is no longer
+on-link, the node cannot install a default route, and it boots unable to reach
+anything. Set the prefix to the **real network's** prefix — usually the same
+`/24` as your LAN — and bound the pool with start and end.
+
+The gateway sits outside the pool, which is normal and expected. What is
+rejected is a gateway outside the *subnet*.
+
+### The pool caps the machine count, not the VMID range
+
+VMIDs are handed out lowest-free-first, so machines fill the pool from the start
+upward and it only ever has to hold the machines running at once. A VMID range
+**wider** than the pool is therefore normal — it just supplies ids.
+
+Size the pool by how many nodes you intend to run, and the VMID range by how
+much id headroom you want. The eleventh machine in the ten-address pool above
+fails with `static IP pool exhausted: 192.168.15.150-192.168.15.159 holds 10
+machines`, naming the capacity so it is actionable.
 
 Requirements and rules:
 
@@ -246,39 +280,25 @@ Requirements and rules:
 - **Cloud-init is always on.** The address is delivered through cloud-init
   `ipconfig0`, and cloud-init writes it persistently, so it survives reboots.
   The driver enables cloud-init unconditionally, so there is nothing to set.
-- **`pve-gateway` must be inside the subnet of `pve-ip-base`.** A gateway the
-  nodes cannot reach is almost always a typo, so it is rejected.
-- **Give each pool its own `pve-ip-base`.** VMIDs are unique cluster-wide (the
-  driver scans `/cluster/resources`), so two pools sharing a VMID range get
-  different VMIDs and different addresses — that is safe. The collision is two
-  pools with *different* range minima but the *same* base: `200-299` and
-  `300-399` both based at `10.10.20.10/24` give VMID 200 and VMID 300 offset 0,
-  so both claim `10.10.20.10`. Use a distinct base per pool, or share both the
-  range and the base.
-- **Exclude the static block from the DHCP scope.** If the scope in Part 1
-  leases `10.10.20.50`–`10.10.20.250`, a static base of `10.10.20.10/24` with a
-  100-wide VMID range stays clear of it. Overlap means DHCP eventually hands a
-  static node's address to something else.
+- **Both ends must be in the same subnet**, and neither may be the subnet's
+  network or broadcast address.
+- **Give each machine pool its own address range.** VMIDs are unique
+  cluster-wide (the driver scans `/cluster/resources`), so two pools sharing a
+  VMID range get different VMIDs and different addresses — that is safe. The
+  collision is two pools with *different* range minima but the *same* start:
+  `200-299` and `300-399` both starting at `192.168.15.150` give VMID 200 and
+  VMID 300 offset 0, so both claim `.150`.
+- **Exclude the pool from the DHCP scope.** If the scope in Part 1 leases
+  `192.168.15.50`–`.149`, a pool of `.150`–`.159` stays clear of it. Overlap
+  means DHCP eventually hands a static node's address to something else — and
+  because the pool has an explicit end, this is now easy to keep exact.
 
-### The subnet caps the pool, not the VMID range
+`PreCreateCheck` rejects a pool straddling two subnets, one that includes the
+network or broadcast address, an end below the start, or a gateway outside the
+subnet. It logs the real capacity when the VMID range exceeds it.
 
-VMIDs are handed out lowest-free-first, so machines fill the subnet upward from
-the base and the subnet only ever has to hold the machines running at once. A
-VMID range **wider** than the subnet is therefore normal and accepted — it just
-supplies ids.
-
-So size the subnet by how many nodes you intend to run, and the VMID range by
-how much id headroom you want. With `pve-ip-base 10.10.20.9/30` (a `/30` spans
-`.8`–`.11`, leaving `.9` and `.10` usable) and `pve-vmid-range 200-299`, the pool
-holds two machines. The third fails with `static IP pool exhausted: ... leaves
-room for 2 machines`, naming the capacity so it is actionable.
-
-`PreCreateCheck` rejects only a base that is unusable outright — the network or
-broadcast address of its subnet, or one with no room before the subnet ends —
-and logs the real capacity when the VMID range exceeds it.
-
-Machine pool: **Addressing (`pve-ip-mode`) = `static`**, **Base address
-(`pve-ip-base`)**, **Gateway (`pve-gateway`)**, plus a **VMID range
+Machine pool: **Addressing (`pve-ip-mode`) = `static`**, **Start address**,
+**End address**, **Subnet prefix**, **Gateway**, plus a **VMID range
 (`pve-vmid-range`)**.
 
 ## Addressing comparison
@@ -346,6 +366,6 @@ Both segments can exist at the same time, so moving from the host-local bridge
 
 Addressing is an independent choice and **does not have to change with the
 segment**. A pool can move from `vmbr2` to the VLAN and stay on DHCP throughout.
-If it is on static addressing, the one thing that must change is `pve-ip-base`
+If it is on static addressing, the one thing that must change is the pool
 and `pve-gateway`, because the new segment is a different subnet — the VMID
 range, and therefore the ordering of the addresses, stays exactly as it was.

--- a/docs/rancher-setup.md
+++ b/docs/rancher-setup.md
@@ -210,8 +210,10 @@ driver flag shows up as a form field; the ones that matter first:
 | Boot disk device | `pve-boot-disk-device` | `scsi0` by default; match your template's boot disk |
 | Cloud-init | `pve-cloudinit` | Always on. The driver enables it regardless: it is the only channel for the SSH key, the static address and the DNS settings |
 | Addressing | `pve-ip-mode` | `DHCP` or `Static` |
-| Base address | `pve-ip-base` | Static only. First address of the pool, e.g. `10.10.20.10/24` |
-| Gateway | `pve-gateway` | Static only. Must be in the base subnet |
+| Start address | `pve-ip-start` | Static only. First address of the pool, e.g. `192.168.15.150` |
+| End address | `pve-ip-end` | Static only. Last address of the pool, e.g. `192.168.15.159`. Caps how many machines the pool holds |
+| Subnet prefix | `pve-ip-prefix` | Static only. The netmask the machines get, e.g. `24`. **Not** the pool size |
+| Gateway | `pve-gateway` | Static only. May sit outside the pool, but must be inside the subnet the prefix describes |
 | DNS servers | `pve-nameservers` | Both modes. Empty keeps the DHCP-supplied resolver |
 | DNS search domain | `pve-searchdomain` | Both modes |
 | Cloud-init user | `pve-ciuser` | e.g. `rancher` for Leap Micro; leave empty for Debian's built-in `debian` user |
@@ -426,8 +428,10 @@ sha256 of the `nodedriver-v*.yaml` file (it's a manifest, not the binary).
 | Pods crash-loop with `Fatal glibc error: CPU does not support x86-64-v2` (often first seen in a `helm-operation-*` pod) | The template was created with PVE's default `kvm64` CPU model, which lacks SSE4.2/POPCNT. Modern container images built against glibc 2.34+ target x86-64-v2 and abort immediately. The node itself provisions fine, so this reads as a Rancher fault rather than a VM one | Set `--cpu x86-64-v2-AES` on the template (see [template preparation](template-preparation.md#a2-create-the-template-vm)). Existing nodes need a full `qm stop` + `qm start` — the CPU model is fixed at VM start, so an in-guest reboot will not pick it up |
 | Node gets an unexpected IP after setting a bridge | Rewriting the net device assigns a new MAC, so DHCP reservations keyed to the old MAC no longer match | Re-key the reservation to the new MAC, or set `pve-ip-mode` to static, which does not depend on DHCP reservations at all |
 | `--pve-ip-mode static requires --pve-vmid-range` | The address is derived from the machine position in the VMID range, so without a range there is no offset to compute | Set a VMID range on the pool, e.g. `200-299` |
-| `static IP pool exhausted: ... leaves room for N machines` | The subnet is full. It caps the pool, not the VMID range, and machines fill it upward from the base | Widen the prefix, lower the base address, or scale the pool down. A VMID range wider than the subnet is fine on its own |
-| `--pve-ip-base ... is the network address` / `is the broadcast address` | The base cannot be assigned to a machine | Use the next address up, e.g. `10.10.20.1/24` rather than `10.10.20.0/24` |
+| `static IP pool exhausted: ... holds N machines` | The pool is full. It caps the machine count, not the VMID range, and machines fill it from the start upward | Raise the end address, or scale the pool down. A VMID range wider than the pool is fine on its own |
+| `the pool includes ... the network address` / `the broadcast address` | An end of the pool lands on an unassignable address | Move that end in by one, e.g. start at `.1` rather than `.0` |
+| `--pve-ip-start ... and --pve-ip-end ... are not in the same /N subnet` | The prefix is too narrow to hold both ends | Widen the subnet prefix to the real network, usually `24` |
+| `--pve-gateway ... is outside ...` | The prefix was set to bound the pool rather than to describe the network, so the gateway is no longer on-link | Set the prefix to the real network prefix and bound the pool with start and end instead |
 | Two pools get the same addresses | They share both a VMID range and an IP base | Give each pool its own VMID range |
 | `--pve-nameservers and --pve-searchdomain need --pve-cloudinit` | DNS reaches the guest as a cloud-init option | Enable cloud-init on the pool, or clear the DNS fields |
 

--- a/docs/template-preparation.md
+++ b/docs/template-preparation.md
@@ -27,7 +27,7 @@ you pick, the five hard requirements are:
    format and mount data disks, so passwordless `sudo` is doubly load-bearing.
 4. **An address for the NIC** — either DHCP on the bridge used for `net0`, or
    driver-assigned static addressing (`--pve-ip-mode static` with
-   `--pve-ip-base` and `--pve-gateway`). See
+   `--pve-ip-start`, `--pve-ip-end`, `--pve-ip-prefix` and `--pve-gateway`). See
    [docs/networking.md](networking.md) for both.
 5. **The packages your storage stack needs, baked into the image.** The driver
    attaches, formats and mounts data disks itself, but it does not install

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -80,7 +80,9 @@ type Driver struct {
 	NetFirewall      string
 	CloudInit        bool
 	IPMode           string
-	IPBase           string
+	IPStart          string
+	IPEnd            string
+	IPPrefix         string
 	Gateway          string
 	Nameservers      string
 	SearchDomain     string
@@ -270,18 +272,28 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.StringFlag{
 			Name:   "pve-ip-mode",
 			EnvVar: "PVE_IP_MODE",
-			Usage:  "How the machine gets its address: dhcp (default) or static. static requires --pve-ip-base, --pve-gateway and --pve-vmid-range",
+			Usage:  "How the machine gets its address: dhcp (default) or static. static requires --pve-ip-start, --pve-ip-end, --pve-ip-prefix, --pve-gateway and --pve-vmid-range",
 			Value:  string(ipModeDHCP),
 		},
 		mcnflag.StringFlag{
-			Name:   "pve-ip-base",
-			EnvVar: "PVE_IP_BASE",
-			Usage:  "First address of the static pool, in CIDR form, e.g. 10.10.20.10/24. The machine with the lowest VMID in --pve-vmid-range gets this address; each later VMID gets the next one",
+			Name:   "pve-ip-start",
+			EnvVar: "PVE_IP_START",
+			Usage:  "First address of the static pool, e.g. 192.168.15.150. The machine with the lowest VMID in --pve-vmid-range gets this address; each later VMID gets the next one",
+		},
+		mcnflag.StringFlag{
+			Name:   "pve-ip-end",
+			EnvVar: "PVE_IP_END",
+			Usage:  "Last address of the static pool, e.g. 192.168.15.159. The pool size caps how many machines the machine pool can hold",
+		},
+		mcnflag.StringFlag{
+			Name:   "pve-ip-prefix",
+			EnvVar: "PVE_IP_PREFIX",
+			Usage:  "Subnet prefix length the machines get, e.g. 24. This is the netmask of the network they sit on, NOT the size of the pool — set it to the real network's prefix so the gateway stays reachable",
 		},
 		mcnflag.StringFlag{
 			Name:   "pve-gateway",
 			EnvVar: "PVE_GATEWAY",
-			Usage:  "Default gateway for static addressing, e.g. 10.10.20.1. Must be inside the subnet of --pve-ip-base",
+			Usage:  "Default gateway for static addressing, e.g. 192.168.15.1. It may sit outside the pool, but must be inside the subnet implied by --pve-ip-prefix",
 		},
 		mcnflag.StringFlag{
 			Name:   "pve-nameservers",
@@ -386,7 +398,9 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	}
 	d.CloudInit = true
 	d.IPMode = strings.TrimSpace(flags.String("pve-ip-mode"))
-	d.IPBase = strings.TrimSpace(flags.String("pve-ip-base"))
+	d.IPStart = strings.TrimSpace(flags.String("pve-ip-start"))
+	d.IPEnd = strings.TrimSpace(flags.String("pve-ip-end"))
+	d.IPPrefix = strings.TrimSpace(flags.String("pve-ip-prefix"))
 	d.Gateway = strings.TrimSpace(flags.String("pve-gateway"))
 	d.Nameservers = strings.TrimSpace(flags.String("pve-nameservers"))
 	d.SearchDomain = strings.TrimSpace(flags.String("pve-searchdomain"))

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -448,7 +448,9 @@ func TestIPFlagsAreDeclared(t *testing.T) {
 
 	want := map[string]bool{
 		"pve-ip-mode":      false,
-		"pve-ip-base":      false,
+		"pve-ip-start":     false,
+		"pve-ip-end":       false,
+		"pve-ip-prefix":    false,
 		"pve-gateway":      false,
 		"pve-nameservers":  false,
 		"pve-searchdomain": false,
@@ -458,8 +460,8 @@ func TestIPFlagsAreDeclared(t *testing.T) {
 		if _, ok := want[name]; ok {
 			want[name] = true
 		}
-		if name == "pve-ipconfig" {
-			t.Error("pve-ipconfig must be removed: one flag cannot express a per-machine address, so every node in a pool would receive the same one")
+		if name == "pve-ipconfig" || name == "pve-ip-base" {
+			t.Errorf("%s must be removed: a single CIDR cannot express both the pool bounds and the node netmask, which is what made /28 mean two different things", name)
 		}
 	}
 	for name, found := range want {

--- a/pkg/driver/ipconfig.go
+++ b/pkg/driver/ipconfig.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/docker/machine/libmachine/log"
@@ -78,22 +80,35 @@ func offsetAddr(addr netip.Addr, n int) (netip.Addr, error) {
 	return netip.AddrFrom4(out), nil
 }
 
-// capacityFrom returns how many machines can be addressed starting at the base,
-// counting up to but not including the subnet's broadcast address.
+// staticPool is the range of addresses a machine pool may hand out, plus the
+// netmask its machines get.
 //
-// This — not the width of the VMID range — is what caps a static pool. VMIDs
-// come from NextFreeVMID, which returns the *lowest* free id in the range, so
-// machines cluster at the bottom of the range and the subnet only ever has to
-// hold the machines that exist at once. Sizing the subnet to the whole VMID
-// range instead demanded a /25 to run three nodes with a 100-wide range.
-func capacityFrom(pfx netip.Prefix) (int, error) {
-	_, broadcast, err := networkAndBroadcast(pfx)
-	if err != nil {
-		return 0, err
-	}
-	first := pfx.Addr().As4()
-	last := broadcast.As4()
-	return int(binary.BigEndian.Uint32(last[:]) - binary.BigEndian.Uint32(first[:])), nil
+// Start and end are separate from the prefix on purpose. The prefix is the
+// node's *netmask* — what it uses to decide whether an address is on-link —
+// while start/end bound the pool. Folding the two into one CIDR made people
+// write /28 to mean "16 addresses", which silently narrowed the subnet until
+// the real gateway fell outside it and the node came up with no default route.
+type staticPool struct {
+	start netip.Addr
+	end   netip.Addr
+	bits  int
+}
+
+// prefix returns the subnet the machines believe they are on.
+func (p staticPool) prefix() netip.Prefix {
+	return netip.PrefixFrom(p.start, p.bits)
+}
+
+// capacity is how many machines the pool can address.
+//
+// This — not the width of the VMID range — is what caps a pool. VMIDs come
+// from NextFreeVMID, which returns the *lowest* free id, so machines fill the
+// pool from the start upward and it only ever has to hold the machines running
+// at once.
+func (p staticPool) capacity() int {
+	s := p.start.As4()
+	e := p.end.As4()
+	return int(binary.BigEndian.Uint32(e[:])-binary.BigEndian.Uint32(s[:])) + 1
 }
 
 // networkAndBroadcast returns the two addresses in pfx that must never be
@@ -109,37 +124,93 @@ func networkAndBroadcast(pfx netip.Prefix) (netip.Addr, netip.Addr, error) {
 	return network, broadcast, nil
 }
 
-// parseIPBase parses --pve-ip-base and rejects everything this design does not
-// support, with a message naming the flag.
-func parseIPBase(base string) (netip.Prefix, error) {
-	pfx, err := netip.ParsePrefix(strings.TrimSpace(base))
+// parseStaticAddr parses one IPv4 address, naming the flag it came from.
+func parseStaticAddr(flag, value string) (netip.Addr, error) {
+	addr, err := netip.ParseAddr(strings.TrimSpace(value))
 	if err != nil {
-		return netip.Prefix{}, fmt.Errorf("pve: --pve-ip-base %q must be an IPv4 address with a prefix, e.g. 10.10.20.10/24", base)
+		return netip.Addr{}, fmt.Errorf("pve: %s %q must be an IPv4 address, e.g. 192.168.15.150", flag, value)
 	}
-	if !pfx.Addr().Is4() {
-		return netip.Prefix{}, fmt.Errorf("pve: --pve-ip-base %q must be IPv4; IPv6 addressing is not supported", base)
+	if !addr.Is4() {
+		return netip.Addr{}, fmt.Errorf("pve: %s %q must be IPv4; IPv6 addressing is not supported", flag, value)
 	}
-	if pfx.Bits() > minStaticPrefixBits {
-		return netip.Prefix{}, fmt.Errorf("pve: --pve-ip-base %q has no usable host addresses; use /30 or larger", base)
+	return addr, nil
+}
+
+// parsePrefixBits parses --pve-ip-prefix, accepting either "24" or "/24".
+func parsePrefixBits(value string) (int, error) {
+	s := strings.TrimPrefix(strings.TrimSpace(value), "/")
+	bits, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("pve: --pve-ip-prefix %q must be a number of bits, e.g. 24", value)
 	}
-	return pfx, nil
+	// Below /8 is never a node network, and above /30 leaves no usable hosts
+	// once the network and broadcast addresses are excluded.
+	if bits < 8 || bits > minStaticPrefixBits {
+		return 0, fmt.Errorf("pve: --pve-ip-prefix /%d is out of range; use a value between /8 and /%d", bits, minStaticPrefixBits)
+	}
+	return bits, nil
+}
+
+// parseStaticPool parses and validates the three pool fields together.
+//
+// The prefix is deliberately its own field. It is the netmask the machines get,
+// not the size of the pool: folding the two into one CIDR led people to write
+// /28 meaning "16 addresses", which narrowed the subnet until the gateway fell
+// outside it and the node booted with no usable default route.
+func parseStaticPool(start, end, prefix string) (staticPool, error) {
+	var p staticPool
+
+	bits, err := parsePrefixBits(prefix)
+	if err != nil {
+		return p, err
+	}
+	first, err := parseStaticAddr("--pve-ip-start", start)
+	if err != nil {
+		return p, err
+	}
+	last, err := parseStaticAddr("--pve-ip-end", end)
+	if err != nil {
+		return p, err
+	}
+	p = staticPool{start: first, end: last, bits: bits}
+
+	if last.Less(first) {
+		return staticPool{}, fmt.Errorf("pve: --pve-ip-end %s is below --pve-ip-start %s", last, first)
+	}
+	// Both ends must sit in the same subnet, or the machines at one end would get
+	// a netmask that does not describe the network they are actually on.
+	subnet := p.prefix().Masked()
+	if !subnet.Contains(last) {
+		return staticPool{}, fmt.Errorf("pve: --pve-ip-start %s and --pve-ip-end %s are not in the same /%d subnet (%s); widen --pve-ip-prefix or move one end", first, last, bits, subnet)
+	}
+	network, broadcast, err := networkAndBroadcast(p.prefix())
+	if err != nil {
+		return staticPool{}, err
+	}
+	if first == network || last == network {
+		return staticPool{}, fmt.Errorf("pve: the pool includes %s, the network address of %s, which cannot be assigned to a machine", network, subnet)
+	}
+	if first == broadcast || last == broadcast {
+		return staticPool{}, fmt.Errorf("pve: the pool includes %s, the broadcast address of %s, which cannot be assigned to a machine", broadcast, subnet)
+	}
+	return p, nil
 }
 
 // buildIPConfig renders the cloud-init ipconfig0 value for one machine.
 //
 // The static address is derived from the VMID rather than allocated, because
 // the driver is a stateless per-machine process with nothing to allocate
-// against. offset = vmid - vmidMin, so the VMID range and the address range
-// stay in lockstep with no coordination and no races.
+// against. offset = vmid - vmidMin, so machines fill the pool from its start
+// upward with no coordination and no races.
 //
 // IMPORTANT: callers must pass the *final* VMID. cloneFromTemplate retries when
 // it loses a VMID claim, so an address computed before the claim settles would
 // belong to a VMID this machine did not get.
-func buildIPConfig(mode ipMode, base, gateway string, vmid, vmidMin int) (string, error) {
+func buildIPConfig(mode ipMode, start, end, prefix, gateway string, vmid, vmidMin int) (string, error) {
 	if mode != ipModeStatic {
 		return "ip=dhcp", nil
 	}
-	pfx, err := parseIPBase(base)
+	pool, err := parseStaticPool(start, end, prefix)
 	if err != nil {
 		return "", err
 	}
@@ -147,84 +218,16 @@ func buildIPConfig(mode ipMode, base, gateway string, vmid, vmidMin int) (string
 	if offset < 0 {
 		return "", fmt.Errorf("pve: VMID %d is below the --pve-vmid-range minimum %d, so it has no address in the pool", vmid, vmidMin)
 	}
-	addr, err := offsetAddr(pfx.Addr(), offset)
+	// The pool, not the VMID range, is what bounds the machine count. Report
+	// exhaustion in those terms so the number is actionable.
+	if capacity := pool.capacity(); offset >= capacity {
+		return "", fmt.Errorf("pve: static IP pool exhausted: %s-%s holds %d machines, and VMID %d needs slot %d; widen the pool or scale down", pool.start, pool.end, capacity, vmid, offset+1)
+	}
+	addr, err := offsetAddr(pool.start, offset)
 	if err != nil {
 		return "", err
 	}
-	// The subnet, not the VMID range, is what bounds the pool. Report exhaustion
-	// in those terms: the operator needs to know how many machines the subnet
-	// can hold, not that some arithmetic left the prefix.
-	capacity, err := capacityFrom(pfx)
-	if err != nil {
-		return "", err
-	}
-	if offset >= capacity {
-		return "", fmt.Errorf("pve: static IP pool exhausted: --pve-ip-base %s leaves room for %d machines from %s, and VMID %d needs offset %d; widen the subnet, lower the base address, or scale the pool down", base, capacity, pfx.Addr(), vmid, offset)
-	}
-	if !pfx.Contains(addr) {
-		return "", fmt.Errorf("pve: VMID %d maps to %s, which is outside the subnet of --pve-ip-base %s", vmid, addr, base)
-	}
-	network, broadcast, err := networkAndBroadcast(pfx)
-	if err != nil {
-		return "", err
-	}
-	if addr == network {
-		return "", fmt.Errorf("pve: VMID %d maps to %s, which is the network address of %s", vmid, addr, base)
-	}
-	if addr == broadcast {
-		return "", fmt.Errorf("pve: VMID %d maps to %s, which is the broadcast address of %s", vmid, addr, base)
-	}
-	return fmt.Sprintf("ip=%s/%d,gw=%s", addr, pfx.Bits(), strings.TrimSpace(gateway)), nil
-}
-
-// validateStaticSpan checks the static addressing config at pool-save time.
-//
-// It deliberately does NOT require the subnet to cover the whole VMID range.
-// NextFreeVMID hands out the lowest free id in the range, so machines cluster
-// at the bottom of it and the subnet only ever has to hold the machines that
-// exist at once. Requiring full coverage forced absurd subnet sizes — a
-// 100-wide VMID range demanded a /25 even to run three nodes.
-//
-// What it does check is that the base address is usable at all, so the errors a
-// user can only hit by scaling are left to buildIPConfig, which reports them as
-// pool exhaustion with a machine count.
-func validateStaticSpan(base, gateway string, vmidMin, vmidMax int) error {
-	pfx, err := parseIPBase(base)
-	if err != nil {
-		return err
-	}
-	gw, err := netip.ParseAddr(strings.TrimSpace(gateway))
-	if err != nil || !gw.Is4() {
-		return fmt.Errorf("pve: --pve-gateway %q must be an IPv4 address", gateway)
-	}
-	if !pfx.Contains(gw) {
-		return fmt.Errorf("pve: --pve-gateway %s is outside the subnet of --pve-ip-base %s; a gateway the nodes cannot reach is almost always a typo", gateway, base)
-	}
-	network, broadcast, err := networkAndBroadcast(pfx)
-	if err != nil {
-		return err
-	}
-	if pfx.Addr() == network {
-		return fmt.Errorf("pve: --pve-ip-base %s is the network address of its subnet, which cannot be assigned to a machine; use the next address", base)
-	}
-	if pfx.Addr() == broadcast {
-		return fmt.Errorf("pve: --pve-ip-base %s is the broadcast address of its subnet, which cannot be assigned to a machine", base)
-	}
-	// The base must leave room for at least one machine. Anything beyond that is
-	// a capacity question, reported per machine by buildIPConfig.
-	capacity, err := capacityFrom(pfx)
-	if err != nil {
-		return err
-	}
-	if capacity < 1 {
-		return fmt.Errorf("pve: --pve-ip-base %s leaves no room for any machine before the end of its subnet; lower the base address or widen the subnet", base)
-	}
-	// Not an error: a VMID range wider than the subnet is a normal way to keep
-	// id headroom. Surface the real capacity so it is not a surprise later.
-	if size := vmidMax - vmidMin + 1; size > capacity {
-		log.Infof("pve: --pve-vmid-range %d-%d allows %d machines but --pve-ip-base %s addresses %d; the pool is capped at %d machines by the subnet", vmidMin, vmidMax, size, base, capacity, capacity)
-	}
-	return nil
+	return fmt.Sprintf("ip=%s/%d,gw=%s", addr, pool.bits, strings.TrimSpace(gateway)), nil
 }
 
 // resolveIPConfig renders the ipconfig0 value for this machine.
@@ -248,7 +251,40 @@ func (d *Driver) resolveIPConfig() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return buildIPConfig(mode, d.IPBase, d.Gateway, d.VMID, vmidMin)
+	return buildIPConfig(mode, d.IPStart, d.IPEnd, d.IPPrefix, d.Gateway, d.VMID, vmidMin)
+}
+
+// validateStaticPool checks the pool and gateway at pool-save time.
+//
+// It deliberately does NOT require the pool to be as large as the VMID range.
+// NextFreeVMID hands out the lowest free id, so machines fill the pool from its
+// start upward and it only has to hold the machines running at once. Requiring
+// full coverage forced absurd pool sizes — a 100-wide VMID range demanded 100
+// addresses even to run three nodes. Exhaustion is reported per machine by
+// buildIPConfig instead, with the pool size named.
+func validateStaticPool(start, end, prefix, gateway string, vmidMin, vmidMax int) error {
+	pool, err := parseStaticPool(start, end, prefix)
+	if err != nil {
+		return err
+	}
+	gw, err := parseStaticAddr("--pve-gateway", gateway)
+	if err != nil {
+		return err
+	}
+	// The gateway belongs to the subnet, not the pool: it is normal and expected
+	// for it to sit outside the pool's range. But a gateway outside the *subnet*
+	// is not reachable on-link, so the node would boot unable to install a
+	// default route.
+	subnet := pool.prefix().Masked()
+	if !subnet.Contains(gw) {
+		return fmt.Errorf("pve: --pve-gateway %s is outside %s, the subnet the machines get from --pve-ip-prefix /%d. The gateway may sit outside the pool %s-%s, but it must be inside the subnet or the node has no on-link route to it — widen --pve-ip-prefix to match the real network", gw, subnet, pool.bits, pool.start, pool.end)
+	}
+	// Not an error: a VMID range wider than the pool is a normal way to keep id
+	// headroom. Surface the real capacity so it is not a surprise later.
+	if capacity, size := pool.capacity(), vmidMax-vmidMin+1; size > capacity {
+		log.Infof("pve: --pve-vmid-range %d-%d allows %d machines but the pool %s-%s holds %d; the pool caps this machine pool at %d", vmidMin, vmidMax, size, pool.start, pool.end, capacity, capacity)
+	}
+	return nil
 }
 
 // validateAddressing checks every addressing and DNS field. It runs in
@@ -275,27 +311,38 @@ func (d *Driver) validateAddressing() error {
 	d.Nameservers = ns
 
 	if mode == ipModeDHCP {
-		// Rejected rather than ignored: a leftover base from a static config
-		// looks like it is in effect, and the node then comes up on a DHCP
+		// Rejected rather than ignored: leftover pool fields from a static config
+		// look like they are in effect, and the node then comes up on a DHCP
 		// address nobody expected.
 		var orphans []string
-		if d.IPBase != "" {
-			orphans = append(orphans, "--pve-ip-base")
-		}
-		if d.Gateway != "" {
-			orphans = append(orphans, "--pve-gateway")
+		for flag, value := range map[string]string{
+			"--pve-ip-start":  d.IPStart,
+			"--pve-ip-end":    d.IPEnd,
+			"--pve-ip-prefix": d.IPPrefix,
+			"--pve-gateway":   d.Gateway,
+		} {
+			if value != "" {
+				orphans = append(orphans, flag)
+			}
 		}
 		if len(orphans) > 0 {
+			sort.Strings(orphans) // map iteration order is random; keep the message stable
 			return fmt.Errorf("pve: %s only apply when --pve-ip-mode is static", strings.Join(orphans, ", "))
 		}
 		return nil
 	}
 
-	if d.IPBase == "" {
-		return errors.New("pve: --pve-ip-base is required when --pve-ip-mode is static")
-	}
-	if d.Gateway == "" {
-		return errors.New("pve: --pve-gateway is required when --pve-ip-mode is static")
+	// Ordered, not a map: the form reports the first missing field, and it should
+	// be the same one the driver names.
+	for _, f := range []struct{ flag, value string }{
+		{"--pve-ip-start", d.IPStart},
+		{"--pve-ip-end", d.IPEnd},
+		{"--pve-ip-prefix", d.IPPrefix},
+		{"--pve-gateway", d.Gateway},
+	} {
+		if strings.TrimSpace(f.value) == "" {
+			return fmt.Errorf("pve: %s is required when --pve-ip-mode is static", f.flag)
+		}
 	}
 	if !d.CloudInit {
 		return errors.New("pve: --pve-ip-mode static needs --pve-cloudinit: the address is delivered through cloud-init ipconfig0")
@@ -309,5 +356,5 @@ func (d *Driver) validateAddressing() error {
 	if err != nil {
 		return err
 	}
-	return validateStaticSpan(d.IPBase, d.Gateway, vmidMin, vmidMax)
+	return validateStaticPool(d.IPStart, d.IPEnd, d.IPPrefix, d.Gateway, vmidMin, vmidMax)
 }

--- a/pkg/driver/ipconfig_test.go
+++ b/pkg/driver/ipconfig_test.go
@@ -79,9 +79,9 @@ func TestNormalizeNameservers(t *testing.T) {
 }
 
 func TestBuildIPConfigDHCP(t *testing.T) {
-	// In dhcp mode the static fields are irrelevant and must be ignored, not
+	// In dhcp mode the pool fields are irrelevant and must be ignored, not
 	// validated: a pool that switches static -> dhcp may still carry them.
-	got, err := buildIPConfig(ipModeDHCP, "10.10.20.10/24", "10.10.20.1", 250, 200)
+	got, err := buildIPConfig(ipModeDHCP, "192.168.15.150", "192.168.15.159", "24", "192.168.15.1", 250, 200)
 	if err != nil {
 		t.Fatalf("buildIPConfig() returned error: %v", err)
 	}
@@ -89,9 +89,9 @@ func TestBuildIPConfigDHCP(t *testing.T) {
 		t.Errorf("buildIPConfig() = %q, want %q", got, "ip=dhcp")
 	}
 
-	got, err = buildIPConfig(ipModeDHCP, "", "", 0, 0)
+	got, err = buildIPConfig(ipModeDHCP, "", "", "", "", 0, 0)
 	if err != nil {
-		t.Fatalf("buildIPConfig() with empty static fields returned error: %v", err)
+		t.Fatalf("buildIPConfig() with empty pool fields returned error: %v", err)
 	}
 	if got != "ip=dhcp" {
 		t.Errorf("buildIPConfig() = %q, want %q", got, "ip=dhcp")
@@ -100,74 +100,107 @@ func TestBuildIPConfigDHCP(t *testing.T) {
 
 func TestBuildIPConfigStatic(t *testing.T) {
 	tests := []struct {
-		name    string
-		base    string
-		gw      string
-		vmid    int
-		vmidMin int
-		want    string
-		wantErr string
+		name                   string
+		start, end, prefix, gw string
+		vmid, vmidMin          int
+		want                   string
+		wantErr                string
 	}{
 		{
-			name: "the first VMID in the range gets the base address",
-			base: "10.10.20.10/24", gw: "10.10.20.1", vmid: 200, vmidMin: 200,
-			want: "ip=10.10.20.10/24,gw=10.10.20.1",
+			name:  "the first VMID in the range gets the start address",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "24", gw: "192.168.15.1",
+			vmid: 200, vmidMin: 200,
+			want: "ip=192.168.15.150/24,gw=192.168.15.1",
 		},
 		{
-			name: "the offset is added to the base",
-			base: "10.10.20.10/24", gw: "10.10.20.1", vmid: 202, vmidMin: 200,
-			want: "ip=10.10.20.12/24,gw=10.10.20.1",
+			name:  "the offset is added to the start address",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "24", gw: "192.168.15.1",
+			vmid: 202, vmidMin: 200,
+			want: "ip=192.168.15.152/24,gw=192.168.15.1",
 		},
 		{
-			name: "the offset carries across an octet boundary on a /16",
-			base: "10.10.20.250/16", gw: "10.10.0.1", vmid: 210, vmidMin: 200,
+			name:  "the last address in the pool is usable",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "24", gw: "192.168.15.1",
+			vmid: 209, vmidMin: 200,
+			want: "ip=192.168.15.159/24,gw=192.168.15.1",
+		},
+		{
+			// The pool, not the netmask, caps the machine count.
+			name:  "one machine past the end of the pool is exhaustion",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "24", gw: "192.168.15.1",
+			vmid: 210, vmidMin: 200,
+			wantErr: "static IP pool exhausted: 192.168.15.150-192.168.15.159 holds 10 machines",
+		},
+		{
+			// The whole point of a separate prefix: a pool far from the gateway
+			// still gets the real network's netmask.
+			name:  "the offset carries across an octet boundary on a /16",
+			start: "10.10.20.250", end: "10.10.21.10", prefix: "16", gw: "10.10.0.1",
+			vmid: 210, vmidMin: 200,
 			want: "ip=10.10.21.4/16,gw=10.10.0.1",
 		},
 		{
-			name: "a VMID below the range minimum is rejected",
-			base: "10.10.20.10/24", gw: "10.10.20.1", vmid: 199, vmidMin: 200,
+			name:  "a VMID below the range minimum is rejected",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "24", gw: "192.168.15.1",
+			vmid: 199, vmidMin: 200,
 			wantErr: "below",
 		},
 		{
-			// The subnet, not the VMID range, caps the pool — so running off the
-			// end is reported as exhaustion with a machine count, which is what
-			// the operator can act on.
-			name: "an address past the end of the subnet is pool exhaustion",
-			base: "10.10.20.250/24", gw: "10.10.20.1", vmid: 210, vmidMin: 200,
-			wantErr: "static IP pool exhausted: --pve-ip-base 10.10.20.250/24 leaves room for 5 machines",
+			name:  "an end below the start is rejected",
+			start: "192.168.15.159", end: "192.168.15.150", prefix: "24", gw: "192.168.15.1",
+			vmid: 200, vmidMin: 200,
+			wantErr: "--pve-ip-end 192.168.15.150 is below --pve-ip-start 192.168.15.159",
 		},
 		{
-			// .250 on a /24 leaves .250-.254 usable, so offset 5 would land on
-			// the broadcast address and is caught by the capacity check first.
-			name: "the address that would be the broadcast address is pool exhaustion",
-			base: "10.10.20.250/24", gw: "10.10.20.1", vmid: 205, vmidMin: 200,
-			wantErr: "needs offset 5",
+			// A prefix too narrow to hold both ends would give the machines a
+			// netmask that does not describe the network they are on.
+			name:  "a pool straddling two subnets is rejected",
+			start: "192.168.15.150", end: "192.168.15.170", prefix: "28", gw: "192.168.15.1",
+			vmid: 200, vmidMin: 200,
+			wantErr: "not in the same /28 subnet",
 		},
 		{
-			name: "the last usable host in the subnet is accepted",
-			base: "10.10.20.250/24", gw: "10.10.20.1", vmid: 204, vmidMin: 200,
-			want: "ip=10.10.20.254/24,gw=10.10.20.1",
-		},
-		{
-			name: "the network address is rejected",
-			base: "10.10.20.0/24", gw: "10.10.20.1", vmid: 200, vmidMin: 200,
+			name:  "a pool containing the network address is rejected",
+			start: "192.168.15.0", end: "192.168.15.10", prefix: "24", gw: "192.168.15.1",
+			vmid: 200, vmidMin: 200,
 			wantErr: "network address",
 		},
 		{
-			name: "an IPv6 base is rejected",
-			base: "2001:db8::10/64", gw: "2001:db8::1", vmid: 200, vmidMin: 200,
-			wantErr: "IPv4",
+			name:  "a pool containing the broadcast address is rejected",
+			start: "192.168.15.250", end: "192.168.15.255", prefix: "24", gw: "192.168.15.1",
+			vmid: 200, vmidMin: 200,
+			wantErr: "broadcast address",
 		},
 		{
-			name: "a base without a prefix is rejected",
-			base: "10.10.20.10", gw: "10.10.20.1", vmid: 200, vmidMin: 200,
-			wantErr: "--pve-ip-base",
+			name:  "an IPv6 start is rejected",
+			start: "2001:db8::10", end: "2001:db8::20", prefix: "24", gw: "2001:db8::1",
+			vmid: 200, vmidMin: 200,
+			wantErr: "IPv6",
+		},
+		{
+			name:  "a non-numeric prefix is rejected",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "/24bits", gw: "192.168.15.1",
+			vmid: 200, vmidMin: 200,
+			wantErr: "--pve-ip-prefix",
+		},
+		{
+			name:  "a prefix with no usable hosts is rejected",
+			start: "192.168.15.150", end: "192.168.15.150", prefix: "31", gw: "192.168.15.1",
+			vmid: 200, vmidMin: 200,
+			wantErr: "out of range",
+		},
+		{
+			// Written with a leading slash, as the UI placeholder shows it.
+			name:  "a prefix written as /24 is accepted",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "/24", gw: "192.168.15.1",
+			vmid: 200, vmidMin: 200,
+			want: "ip=192.168.15.150/24,gw=192.168.15.1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildIPConfig(ipModeStatic, tt.base, tt.gw, tt.vmid, tt.vmidMin)
+			got, err := buildIPConfig(ipModeStatic, tt.start, tt.end, tt.prefix, tt.gw, tt.vmid, tt.vmidMin)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("buildIPConfig() = %q, want an error mentioning %q", got, tt.wantErr)
@@ -187,58 +220,65 @@ func TestBuildIPConfigStatic(t *testing.T) {
 	}
 }
 
-// validateStaticSpan is a save-time sanity check on the base and gateway. It
-// deliberately does NOT require the subnet to cover the whole VMID range:
-// NextFreeVMID hands out the lowest free id, so machines cluster at the bottom
-// of the range and the subnet only has to hold the machines that exist at once.
-// Capacity is enforced per machine by buildIPConfig instead.
-func TestValidateStaticSpan(t *testing.T) {
+// validateStaticPool is a save-time check on the pool and gateway. It
+// deliberately does NOT require the pool to be as large as the VMID range:
+// NextFreeVMID hands out the lowest free id, so machines fill the pool from its
+// start upward. Capacity is enforced per machine by buildIPConfig.
+func TestValidateStaticPool(t *testing.T) {
 	tests := []struct {
-		name    string
-		base    string
-		gw      string
-		lo, hi  int
-		wantErr string
+		name                   string
+		start, end, prefix, gw string
+		lo, hi                 int
+		wantErr                string
 	}{
-		{name: "a range that fits", base: "10.10.20.10/24", gw: "10.10.20.1", lo: 200, hi: 299},
-		{name: "a range that exactly reaches the last host", base: "10.10.20.10/24", gw: "10.10.20.1", lo: 200, hi: 444},
 		{
-			// Accepted on purpose. A VMID range wider than the subnet is a normal
-			// way to keep id headroom; the subnet simply caps how many machines
-			// can exist. Requiring full coverage demanded a /25 to run three
-			// nodes with a 100-wide range.
-			name: "a VMID range wider than the subnet is accepted", base: "10.10.20.200/24", gw: "10.10.20.1", lo: 200, hi: 299,
+			name:  "a pool smaller than the VMID range is accepted",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "24", gw: "192.168.15.1",
+			lo: 200, hi: 299,
 		},
 		{
-			name: "a /30 base with a wide VMID range is accepted", base: "10.10.20.9/30", gw: "10.10.20.10", lo: 200, hi: 299,
+			// The case that started this: the gateway is outside the pool, which
+			// is normal, but inside the subnet, which is what matters.
+			name:  "a gateway outside the pool but inside the subnet is accepted",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "24", gw: "192.168.15.1",
+			lo: 200, hi: 209,
 		},
 		{
-			name: "a base that is the network address is rejected", base: "10.10.20.0/24", gw: "10.10.20.1", lo: 200, hi: 299,
-			wantErr: "is the network address",
+			// The /28 mistake: it narrows the subnet to .144-.159 so .1 is no
+			// longer on-link, and the node would boot with no default route.
+			// The pool stops at .158 here so the broadcast check does not fire
+			// first and mask the gateway error being tested.
+			name:  "a gateway outside the subnet is rejected",
+			start: "192.168.15.150", end: "192.168.15.158", prefix: "28", gw: "192.168.15.1",
+			lo: 200, hi: 299,
+			wantErr: "outside 192.168.15.144/28",
 		},
 		{
-			name: "a base with no room before the end of the subnet is rejected", base: "10.10.20.255/24", gw: "10.10.20.1", lo: 200, hi: 299,
-			wantErr: "is the broadcast address",
+			// The exact config that prompted this design: /28 also drags .159
+			// into being the broadcast address, which is caught first.
+			name:  "a /28 pool ending on the subnet broadcast is rejected",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "28", gw: "192.168.15.1",
+			lo: 200, hi: 299,
+			wantErr: "broadcast address of 192.168.15.144/28",
 		},
 		{
-			name: "a gateway outside the subnet", base: "10.10.20.10/24", gw: "10.10.99.1", lo: 200, hi: 299,
-			wantErr: "--pve-gateway 10.10.99.1 is outside the subnet",
-		},
-		{
-			name: "a malformed gateway", base: "10.10.20.10/24", gw: "not-an-ip", lo: 200, hi: 299,
+			name:  "a malformed gateway is rejected",
+			start: "192.168.15.150", end: "192.168.15.159", prefix: "24", gw: "not-an-ip",
+			lo: 200, hi: 299,
 			wantErr: "--pve-gateway",
 		},
 		{
-			name: "a prefix too small to hold hosts", base: "10.10.20.10/31", gw: "10.10.20.11", lo: 200, hi: 200,
-			wantErr: "/30",
+			name:  "a single-address pool is accepted",
+			start: "192.168.15.150", end: "192.168.15.150", prefix: "24", gw: "192.168.15.1",
+			lo: 200, hi: 299,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateStaticSpan(tt.base, tt.gw, tt.lo, tt.hi)
+			err := validateStaticPool(tt.start, tt.end, tt.prefix, tt.gw, tt.lo, tt.hi)
 			if tt.wantErr != "" {
 				if err == nil {
-					t.Fatalf("validateStaticSpan() = nil, want an error mentioning %q", tt.wantErr)
+					t.Fatalf("validateStaticPool() = nil, want an error mentioning %q", tt.wantErr)
 				}
 				if !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("error = %q, want it to mention %q", err, tt.wantErr)
@@ -246,7 +286,7 @@ func TestValidateStaticSpan(t *testing.T) {
 				return
 			}
 			if err != nil {
-				t.Fatalf("validateStaticSpan() returned error: %v", err)
+				t.Fatalf("validateStaticPool() returned error: %v", err)
 			}
 		})
 	}
@@ -262,6 +302,7 @@ func newValidatedDriver() *Driver {
 	d.APITokenSecret = "secret"
 	d.TemplateVMID = 9000
 	d.SkipPermCheck = true
+
 	return d
 }
 
@@ -269,7 +310,9 @@ func TestPreCreateCheckStaticRequiresVMIDRange(t *testing.T) {
 	d := newValidatedDriver()
 	d.CloudInit = true // validateAddressing checks cloud-init before the range
 	d.IPMode = "static"
-	d.IPBase = "10.10.20.10/24"
+	d.IPStart = "10.10.20.10"
+	d.IPEnd = "10.10.20.109"
+	d.IPPrefix = "24"
 	d.Gateway = "10.10.20.1"
 	d.VMIDRange = "" // the offset is undefined without it
 
@@ -290,7 +333,9 @@ func TestPreCreateCheckAcceptsSubnetSmallerThanVMIDRange(t *testing.T) {
 	d := newValidatedDriver()
 	d.CloudInit = true
 	d.IPMode = "static"
-	d.IPBase = "10.10.20.9/30"
+	d.IPStart = "10.10.20.9"
+	d.IPEnd = "10.10.20.10"
+	d.IPPrefix = "24"
 	d.Gateway = "10.10.20.10"
 	d.VMIDRange = "200-299"
 
@@ -304,14 +349,16 @@ func TestStaticPoolExhaustionIsReportedPerMachine(t *testing.T) {
 	d := newValidatedDriver()
 	d.CloudInit = true
 	d.IPMode = "static"
-	d.IPBase = "10.10.20.9/30"
+	d.IPStart = "10.10.20.9"
+	d.IPEnd = "10.10.20.10"
+	d.IPPrefix = "24"
 	d.Gateway = "10.10.20.10"
 	d.VMIDRange = "200-299"
 
 	// .9 on a /30 (.8-.11) leaves .9 and .10 usable, so two machines fit.
 	for vmid, want := range map[int]string{
-		200: "ip=10.10.20.9/30,gw=10.10.20.10",
-		201: "ip=10.10.20.10/30,gw=10.10.20.10",
+		200: "ip=10.10.20.9/24,gw=10.10.20.10",
+		201: "ip=10.10.20.10/24,gw=10.10.20.10",
 	} {
 		d.VMID = vmid
 		got, err := d.resolveIPConfig()
@@ -332,7 +379,7 @@ func TestStaticPoolExhaustionIsReportedPerMachine(t *testing.T) {
 	if !strings.Contains(err.Error(), "static IP pool exhausted") {
 		t.Errorf("error = %q, want it to report pool exhaustion", err)
 	}
-	if !strings.Contains(err.Error(), "room for 2 machines") {
+	if !strings.Contains(err.Error(), "holds 2 machines") {
 		t.Errorf("error = %q, want it to state the capacity so the operator can act on it", err)
 	}
 }
@@ -340,14 +387,16 @@ func TestStaticPoolExhaustionIsReportedPerMachine(t *testing.T) {
 func TestPreCreateCheckRejectsStaticFieldsInDHCPMode(t *testing.T) {
 	d := newValidatedDriver()
 	d.IPMode = "dhcp"
-	d.IPBase = "10.10.20.10/24"
+	d.IPStart = "10.10.20.10"
+	d.IPEnd = "10.10.20.109"
+	d.IPPrefix = "24"
 
 	err := d.PreCreateCheck()
 	if err == nil {
-		t.Fatal("PreCreateCheck() = nil, want an error about --pve-ip-base in dhcp mode")
+		t.Fatal("PreCreateCheck() = nil, want an error about the pool fields in dhcp mode")
 	}
-	if !strings.Contains(err.Error(), "--pve-ip-base") {
-		t.Errorf("error = %q, want it to mention --pve-ip-base", err)
+	if !strings.Contains(err.Error(), "--pve-ip-start") {
+		t.Errorf("error = %q, want it to mention --pve-ip-start", err)
 	}
 }
 
@@ -371,7 +420,9 @@ func TestPreCreateCheckAcceptsValidStaticConfig(t *testing.T) {
 	d := newValidatedDriver()
 	d.CloudInit = true
 	d.IPMode = "static"
-	d.IPBase = "10.10.20.10/24"
+	d.IPStart = "10.10.20.10"
+	d.IPEnd = "10.10.20.109"
+	d.IPPrefix = "24"
 	d.Gateway = "10.10.20.1"
 	d.Nameservers = "10.10.20.1, 1.1.1.1"
 	d.SearchDomain = "cluster.lan"
@@ -393,7 +444,9 @@ func TestResolveIPConfigUsesFinalVMID(t *testing.T) {
 	d := newValidatedDriver()
 	d.CloudInit = true
 	d.IPMode = "static"
-	d.IPBase = "10.10.20.10/24"
+	d.IPStart = "10.10.20.10"
+	d.IPEnd = "10.10.20.109"
+	d.IPPrefix = "24"
 	d.Gateway = "10.10.20.1"
 	d.VMIDRange = "200-299"
 
@@ -417,7 +470,9 @@ func TestResolveIPConfigStaticWithoutVMIDRange(t *testing.T) {
 	d := newValidatedDriver()
 	d.CloudInit = true
 	d.IPMode = "static"
-	d.IPBase = "10.10.20.10/24"
+	d.IPStart = "10.10.20.10"
+	d.IPEnd = "10.10.20.109"
+	d.IPPrefix = "24"
 	d.Gateway = "10.10.20.1"
 	d.VMIDRange = ""
 	d.VMID = 202


### PR DESCRIPTION
Replace pve-ip-base with three fields: pve-ip-start, pve-ip-end and pve-ip-prefix.

A single CIDR made the prefix do two jobs at once — bound the pool and set the machines' netmask — so writing /28 to mean "16 addresses" silently narrowed the subnet instead. With 192.168.15.150/28 the subnet becomes .144-.159, a gateway at .1 is no longer on-link, and the node boots unable to install a default route. Separating them makes the pool explicit and leaves the prefix describing the real network, which is also what Metal3 IPPool, Harvester and ISC dhcpd all do.

The pool now caps the machine count rather than the netmask doing it. NextFreeVMID hands out the lowest free id, so machines fill the pool from its start upward and it only has to hold the machines running at once; a VMID range wider than the pool is normal and accepted. Exhaustion is reported per machine with the capacity named.

Also force cloud-init on. It is the only channel carrying the SSH key the driver needs for data disks and Rancher needs to bootstrap, plus ipconfig0 and the DNS options, so a node provisioned without it comes up and never reaches Ready. The flag stays declared rather than deleted: removing it would drop the field from the CRD schema while existing pools still carry it, and Rancher would then pass --pve-cloudinit to a driver that no longer defines it.

Validation gains checks the old model could not express: both pool ends in one subnet, neither end on the network or broadcast address, and an end below the start.