### PR TITLE
Feat:  template-by-tag, clone target, description and cloud-init wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ PVE REST API ◄──┘       ├─ Resolve target node (or first online node
                         ├─ Start the VM
                         ├─ Capture the NIC MAC, then poll the QEMU guest
                         │   agent for the IPv4 on that exact interface
-                        └─ SSH in and format/mount the data disks
+                        ├─ SSH in and wait for cloud-init to report done
+                        └─ Format/mount the data disks
                             → returns "created" once the disks are mounted
 ```
 

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -12,8 +12,8 @@ apiVersion: v2
 name: pve-rancher-driver
 description: Registers the Proxmox VE node driver with Rancher so RKE2/K3s machine pools can provision PVE virtual machines
 type: application
-version: "0.6.2"
-appVersion: "0.6.2"
+version: "0.7.0"
+appVersion: "0.7.0"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/lore09/pve-rancher-driver
 sources:

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -36,6 +36,8 @@ be created in is a property of the token's ACL — a token scoped to
 | `pve-template-tag` | *(empty)* | Select the template by PVE tag instead of VMID, e.g. `rancher-node`. Comma-separated tags must all match, and exactly one template must match. See below |
 | `pve-template-tag-match` | `subset` | `subset` (template carries at least the given tags) or `exact` (its tags are exactly the given ones) |
 | `pve-linked-clone` | `false` | Clone as a linked clone instead of a full clone. See below |
+| `pve-clone-storage` | *(template's own)* | PVE storage id the clone's disks are created on, e.g. `ceph-rbd`. Full clones only. See below |
+| `pve-clone-format` | *(storage default)* | Disk format for the clone: `raw`, `qcow2` or `vmdk`. Full clones only. See below |
 | `pve-vmid` | `0` | Explicit VMID for the created VM, `0` = auto-assigned. Only meaningful for a single machine; mutually exclusive with `pve-vmid-range` |
 | `pve-vmid-range` | *(empty)* | Allocate the VMID from this inclusive range, e.g. `200-299`. Empty lets Proxmox pick the next free id cluster-wide. See below |
 | `pve-allowed-nodes` | *(empty)* | Comma-separated PVE node names the driver may place new VMs on, e.g. `pve1,pve2`. Empty considers every online node. Mutually exclusive with `pve-node`. See below |
@@ -60,6 +62,42 @@ the race is invisible in normal use. If the range fills up, provisioning fails
 with a clear error rather than silently spilling outside it.
 
 Valid ids are `100`-`999999999`; Proxmox reserves `1`-`99`.
+
+### Where the clone's disks land
+
+By default PVE creates a clone's disks on **the storage the template's disks
+are on**. That is an inherited default, not a chosen one, and it pins every
+machine pool cloning a given template to wherever that template happens to
+live: putting nodes on Ceph when the template sits on `local-lvm` would
+otherwise mean building a second template.
+
+`pve-clone-storage` names the destination storage instead — the same thing as
+the *Target Storage* dropdown in PVE's own clone dialog. Three cases where it
+matters:
+
+- **Different backends per pool.** One template, worker nodes on fast local
+  NVMe, control-plane nodes on shared storage.
+- **Linked clones on a template that cannot support them.** `pve-linked-clone`
+  needs snapshot-capable storage; if the template lives on plain LVM, full-clone
+  it once onto LVM-thin/ZFS with this flag and everything downstream works.
+- **Capacity.** Ten full clones of a 20 GB template is 200 GB, and without this
+  it all lands wherever the template is.
+
+`pve-clone-format` (`raw`, `qcow2`, `vmdk`) picks the disk format. Leave it
+empty unless you have a specific reason: the format is only selectable on
+file-based storages (dir, NFS, CIFS), and block backends (LVM, ZFS, Ceph RBD)
+reject anything but their own. The one common use is forcing `qcow2` on NFS so
+the VMs support snapshots.
+
+Two constraints:
+
+- **Both are full-clone-only.** A linked clone is an overlay on the template's
+  own disk, so it has no separate storage to land on and no format to choose.
+  Combining either with `pve-linked-clone` is rejected in `PreCreateCheck`.
+- **Neither lifts the cross-node rule.** Setting a destination storage does not
+  let a template on local storage be cloned to a different node — PVE still
+  requires the source template on shared storage for that, exactly as described
+  under [`pve-allowed-nodes`](#pve-allowed-nodes).
 
 ### Selecting the template by tag
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -38,6 +38,7 @@ be created in is a property of the token's ACL — a token scoped to
 | `pve-vmid-range` | *(empty)* | Allocate the VMID from this inclusive range, e.g. `200-299`. Empty lets Proxmox pick the next free id cluster-wide. See below |
 | `pve-allowed-nodes` | *(empty)* | Comma-separated PVE node names the driver may place new VMs on, e.g. `pve1,pve2`. Empty considers every online node. Mutually exclusive with `pve-node`. See below |
 | `pve-tags` | *(empty)* | Comma-separated PVE tags applied to the VM, e.g. `rancher,prod`. Informational only — for finding/filtering VMs in the PVE UI |
+| `pve-description` | *(default text)* | VM Notes field. Empty writes a line naming the machine, the template it came from and the driver. See below |
 | `pve-vm-name-prefix` | *(empty)* | Prefix for the PVE VM name, rendered as `<prefix>-<machine name>`. Empty uses the machine name unchanged. Letters, digits and inner hyphens only — PVE validates the result as a DNS name, and the whole name must fit 63 characters |
 | `pve-onboot` | `false` | Start the VM automatically when the PVE host boots |
 
@@ -57,6 +58,15 @@ the race is invisible in normal use. If the range fills up, provisioning fails
 with a clear error rather than silently spilling outside it.
 
 Valid ids are `100`-`999999999`; Proxmox reserves `1`-`99`.
+
+### `pve-description`
+
+Cloning copies the template's Notes field, so without this every machine in PVE
+carries text describing the *template* — build date, image recipe, "do not
+start this VM". The driver overwrites it with a line naming the machine, the
+template VMID it was cloned from, and the fact that Rancher manages it, so an
+unfamiliar VM in the PVE UI can be identified without cross-referencing
+Rancher. Set `pve-description` to replace that text with your own.
 
 ### `pve-linked-clone`
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -212,6 +212,7 @@ the exact system paths are refused.
 | `pve-net-firewall` | *(empty)* | `true`/`false` to toggle the PVE firewall on the NIC; empty keeps the PVE default. Requires `pve-net-bridge` |
 | `pve-net-iface` | *(empty)* | Restrict IP discovery to this guest interface name. Rarely needed — MAC matching already pins it |
 | `pve-agent-timeout` | `300` | Seconds to wait for the QEMU guest agent to report an IP |
+| `pve-cloudinit-timeout` | `300` | Seconds to wait for cloud-init to finish inside the guest before handing the machine to Rancher. `0` skips the wait. See below |
 | `pve-provision-delay` | `30` | Seconds to wait after the VM is up before handing it to Rancher for provisioning. See below |
 
 The four settings marked *Requires `pve-net-bridge`* are only written while
@@ -219,6 +220,36 @@ rewriting the NIC, which only happens when a bridge is named. `PreCreateCheck`
 rejects them without one rather than silently ignoring a VLAN you asked for.
 
 See [networking.md](networking.md) for how to build the node network itself.
+
+### `pve-cloudinit-timeout`
+
+After the VM is up and its address is known, the driver SSHes in and runs
+`cloud-init status --wait`, blocking until the guest itself reports that
+cloud-init has finished. This is the readiness signal `pve-provision-delay`
+only approximates: instead of guessing at a duration, the driver waits for the
+thing it actually cares about — the resolver written, the default route
+installed, the login user created.
+
+It runs **before** data-disk setup, so the driver never partitions and mounts
+while cloud-init is still growing the root filesystem or rewriting fstab.
+
+Outcomes:
+
+| In the guest | Driver behaviour |
+|---|---|
+| cloud-init finished cleanly | Continues |
+| Finished with recoverable errors (a failed optional module) | Continues, logging a warning — worth checking first if the node later misbehaves |
+| cloud-init is not installed | Skips the wait, logging that it did |
+| cloud-init failed | Create fails, rather than handing Rancher a broken guest |
+| Did not finish within the timeout | Create fails, naming this flag |
+
+Set it to `0` to skip the wait entirely. With the wait on, `pve-provision-delay`
+is usually redundant and can be lowered or set to `0` — the delay exists
+precisely because the driver had no way to know when cloud-init was done.
+
+The wait needs SSH, which means the cloud-init key injection has to have worked;
+a template whose `pve-ssh-user` is wrong fails here instead of failing later
+during Rancher's bootstrap, which is a considerably clearer error.
 
 ### `pve-provision-delay`
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -32,7 +32,9 @@ be created in is a property of the token's ACL — a token scoped to
 | Flag | Default | Description |
 |------|---------|-------------|
 | `pve-node` | *(first online)* | Target PVE node name |
-| `pve-template-vmid` | *(required)* | Template VMID to clone from |
+| `pve-template-vmid` | *(required)* | Template VMID to clone from. Mutually exclusive with `pve-template-tag` |
+| `pve-template-tag` | *(empty)* | Select the template by PVE tag instead of VMID, e.g. `rancher-node`. Comma-separated tags must all match, and exactly one template must match. See below |
+| `pve-template-tag-match` | `subset` | `subset` (template carries at least the given tags) or `exact` (its tags are exactly the given ones) |
 | `pve-linked-clone` | `false` | Clone as a linked clone instead of a full clone. See below |
 | `pve-vmid` | `0` | Explicit VMID for the created VM, `0` = auto-assigned. Only meaningful for a single machine; mutually exclusive with `pve-vmid-range` |
 | `pve-vmid-range` | *(empty)* | Allocate the VMID from this inclusive range, e.g. `200-299`. Empty lets Proxmox pick the next free id cluster-wide. See below |
@@ -58,6 +60,39 @@ the race is invisible in normal use. If the range fills up, provisioning fails
 with a clear error rather than silently spilling outside it.
 
 Valid ids are `100`-`999999999`; Proxmox reserves `1`-`99`.
+
+### Selecting the template by tag
+
+`pve-template-vmid` pins a machine pool to one specific template VM. That is
+fine until you rebuild the image: the new template gets a new VMID, and every
+machine pool that should use it has to be edited — and a pool still pointing at
+a deleted VMID fails to provision with a Proxmox-side error.
+
+`pve-template-tag` names the *image* instead. Tag the template `rancher-node`
+in the PVE UI, set `pve-template-tag=rancher-node`, and rolling out a rebuilt
+image is one operation on the PVE side: remove the tag from the old template,
+put it on the new one. Machines created after that clone the new one; nothing
+in Rancher changes.
+
+Resolution happens per machine, at create time — not once when the pool is
+saved. Retagging halfway through a scale-up means the machines already created
+keep the old image and the ones after it get the new one, which is what you
+want for a rolling image update and worth knowing before scaling a pool during
+a rebuild.
+
+**Exactly one template must match**, or provisioning fails naming every
+candidate. This is deliberate: two templates carrying the same tag is what a
+half-finished rollout looks like, and quietly picking one would build half a
+machine pool from each image. Matching is:
+
+| Policy | Matches when |
+|---|---|
+| `subset` (default) | The template carries **at least** the tags you listed. Extra tags — `debian13`, a build date — are ignored |
+| `exact` | The template's tag set is **exactly** the one you listed |
+
+Use `subset` unless you deliberately tag templates as complete sets. Note that a
+token which cannot see a template's node gets an empty list rather than an
+error, so "no template matches" can also mean a missing ACL.
 
 ### `pve-description`
 

--- a/docs/rancher-setup.md
+++ b/docs/rancher-setup.md
@@ -207,6 +207,8 @@ driver flag shows up as a form field; the ones that matter first:
 | Template VMID | `pve-template-vmid` | From the [template guide](template-preparation.md), e.g. `9000`. Mutually exclusive with Template tag |
 | Template tag | `pve-template-tag` | Alternative to the VMID: pick the template by PVE tag, e.g. `rancher-node`. Exactly one template must carry it. Lets a rebuilt image be rolled out by moving the tag instead of editing every machine pool — see [flags.md](flags.md#selecting-the-template-by-tag) |
 | Template tag match | `pve-template-tag-match` | `subset` (default) or `exact`. Only read when Template tag is set |
+| Clone storage | `pve-clone-storage` | PVE storage id the clone's disks land on, e.g. `ceph-rbd`. Empty uses the template's own storage. Full clones only — see [flags.md](flags.md#where-the-clones-disks-land) |
+| Clone format | `pve-clone-format` | `raw`, `qcow2` or `vmdk`. Leave empty unless the target is file-based storage (dir/NFS/CIFS); block storages reject anything but their own |
 | Linked clone | `pve-linked-clone` | Off by default (full clone). See the warning in the UI and [flags.md](flags.md#pve-linked-clone) before turning it on |
 | Node | `pve-node` | Leave empty to let the driver pick automatically. Mutually exclusive with Allowed nodes |
 | Allowed nodes | `pve-allowed-nodes` | Comma-separated node names the driver may place VMs on, e.g. `pve1,pve2`. Empty considers every online node. No effect on a single-node install |

--- a/docs/rancher-setup.md
+++ b/docs/rancher-setup.md
@@ -204,7 +204,9 @@ driver flag shows up as a form field; the ones that matter first:
 
 | Field (UI) | Flag | Notes |
 |---|---|---|
-| Template VMID | `pve-template-vmid` | From the [template guide](template-preparation.md), e.g. `9000` |
+| Template VMID | `pve-template-vmid` | From the [template guide](template-preparation.md), e.g. `9000`. Mutually exclusive with Template tag |
+| Template tag | `pve-template-tag` | Alternative to the VMID: pick the template by PVE tag, e.g. `rancher-node`. Exactly one template must carry it. Lets a rebuilt image be rolled out by moving the tag instead of editing every machine pool — see [flags.md](flags.md#selecting-the-template-by-tag) |
+| Template tag match | `pve-template-tag-match` | `subset` (default) or `exact`. Only read when Template tag is set |
 | Linked clone | `pve-linked-clone` | Off by default (full clone). See the warning in the UI and [flags.md](flags.md#pve-linked-clone) before turning it on |
 | Node | `pve-node` | Leave empty to let the driver pick automatically. Mutually exclusive with Allowed nodes |
 | Allowed nodes | `pve-allowed-nodes` | Comma-separated node names the driver may place VMs on, e.g. `pve1,pve2`. Empty considers every online node. No effect on a single-node install |

--- a/docs/rancher-setup.md
+++ b/docs/rancher-setup.md
@@ -209,6 +209,7 @@ driver flag shows up as a form field; the ones that matter first:
 | Node | `pve-node` | Leave empty to let the driver pick automatically. Mutually exclusive with Allowed nodes |
 | Allowed nodes | `pve-allowed-nodes` | Comma-separated node names the driver may place VMs on, e.g. `pve1,pve2`. Empty considers every online node. No effect on a single-node install |
 | Tags | `pve-tags` | Comma-separated PVE tags, e.g. `rancher,prod`. Informational only |
+| Description | `pve-description` | VM Notes text. Empty writes a default naming the machine and its template, replacing the template's own notes that the clone would otherwise inherit |
 | VMID | `pve-vmid` | `0` = PVE auto-assigns (recommended) |
 | Cores / Sockets / Memory | `pve-cores` / `pve-sockets` / `pve-memory` | Per-VM sizing |
 | Network device | `pve-net-device` | Which PVE NIC's MAC is used for IP discovery (`net0`), and the device the settings below rewrite |

--- a/docs/rancher-setup.md
+++ b/docs/rancher-setup.md
@@ -234,7 +234,8 @@ driver flag shows up as a form field; the ones that matter first:
 | VM name prefix | `pve-vm-name-prefix` | Optional. Rendered as `<prefix>-<machine name>`, e.g. `k8s-mycluster-pool1-x7k2p`. Empty uses the machine name unchanged. Letters, digits and inner hyphens only |
 | Data Disks | `pve-data-disk` | One row per disk; repeatable. See [Data disks](#data-disks) below |
 | Agent timeout | `pve-agent-timeout` | Seconds to wait for the guest-agent IP (default 300) |
-| Provision delay | `pve-provision-delay` | Seconds to wait after the VM is up before Rancher provisions it (default 30). Raise it if bootstrap fails against a guest whose network is not ready yet — see [flags.md](flags.md#pve-provision-delay) |
+| Cloud-init timeout | `pve-cloudinit-timeout` | Seconds to wait for `cloud-init status --wait` inside the guest before handing the machine to Rancher (default 300, `0` skips). This is the real readiness check that Provision delay only approximates — see [flags.md](flags.md#pve-cloudinit-timeout) |
+| Provision delay | `pve-provision-delay` | Seconds to wait after the VM is up before Rancher provisions it (default 30). Largely redundant once Cloud-init timeout is on, and can be lowered or set to 0; raise it if bootstrap still fails against a guest whose network is not ready yet — see [flags.md](flags.md#pve-provision-delay) |
 | On boot | `pve-onboot` | Autostart VM with the PVE host |
 
 One pool per role (control-plane, etcd, worker) is normal; workers are where

--- a/pkg/driver/cloudinitwait.go
+++ b/pkg/driver/cloudinitwait.go
@@ -1,0 +1,136 @@
+package driver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/docker/machine/libmachine/drivers"
+	"github.com/docker/machine/libmachine/log"
+)
+
+// cloudInitWaitScript blocks until cloud-init has finished, then reports what
+// happened on a single machine-readable line.
+//
+// It always exits 0 and encodes the real result in `pve-cloudinit-result=`,
+// because a non-zero exit from the SSH command would be indistinguishable
+// from the connection itself failing — and the two want different handling:
+// one is a guest that is up but degraded, the other is a guest the driver
+// cannot reach at all.
+//
+// `cloud-init status --wait` is the supported way to ask this question. Its
+// exit code is 0 when everything ran, 2 when cloud-init finished with
+// recoverable errors (a failed optional module, typically), and non-zero
+// otherwise. It is run without sudo first because on most images the status
+// file is world-readable; the sudo retry covers the images where it is not.
+const cloudInitWaitScript = `
+if ! command -v cloud-init >/dev/null 2>&1; then
+  echo "pve-cloudinit-result=absent"
+  exit 0
+fi
+cloud-init status --wait >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+  sudo cloud-init status --wait >/dev/null 2>&1
+  rc=$?
+fi
+echo "pve-cloudinit-result=$rc"
+cloud-init status --long 2>/dev/null | tr '\n' ' ' || true
+exit 0
+`
+
+// waitForCloudInit blocks until cloud-init inside the guest reports that it
+// has finished, and is what makes a machine genuinely ready rather than
+// merely reachable.
+//
+// The problem it solves: sshd comes up early on most cloud images, well
+// before cloud-init has written the resolver, installed the default route or
+// created the login user. Rancher fires its first bootstrap command the
+// moment SSH answers, so without this the command can run against a
+// half-configured guest and fail on something transient — and a failed
+// bootstrap deletes and recreates the whole machine, often in a loop.
+// --pve-provision-delay only guesses at how long that takes; this waits for
+// the guest to say so.
+//
+// A guest with no cloud-init installed is not an error: the driver logs it
+// and moves on, because the template may legitimately be configured some
+// other way. Cloud-init finishing *with* recoverable errors is also not an
+// error — a failed optional module is common and rarely fatal to the node —
+// but it is logged loudly, since it is the first thing worth looking at if
+// the node later misbehaves.
+func (d *Driver) waitForCloudInit() error {
+	if d.CloudInitTimeout <= 0 {
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		log.Infof("pve: waiting for cloud-init to finish on %s (up to %s, --pve-cloudinit-timeout)", d.IPAddress, d.CloudInitTimeout)
+		if err := drivers.WaitForSSH(d); err != nil {
+			done <- fmt.Errorf("pve: SSH never became available to wait for cloud-init: %w", err)
+			return
+		}
+		out, err := drivers.RunSSHCommandFromDriver(d, cloudInitWaitScript)
+		if err != nil {
+			done <- fmt.Errorf("pve: could not query cloud-init status: %w (guest output: %s)", err, strings.TrimSpace(out))
+			return
+		}
+		done <- interpretCloudInitResult(out)
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(d.CloudInitTimeout):
+		return fmt.Errorf("pve: cloud-init did not finish within %s; raise --pve-cloudinit-timeout, or set it to 0 to hand the machine over without waiting", d.CloudInitTimeout)
+	}
+}
+
+// interpretCloudInitResult turns the script's output into a driver result.
+// Anything it cannot parse is treated as "cannot tell" and allowed through
+// with a warning: refusing to provision because a status line was unfamiliar
+// would be a worse failure than the one being guarded against.
+func interpretCloudInitResult(out string) error {
+	detail := strings.TrimSpace(out)
+	code, ok := parseCloudInitResult(out)
+	if !ok {
+		log.Warnf("pve: could not read cloud-init status from the guest (output: %s); continuing", detail)
+		return nil
+	}
+	switch code {
+	case "absent":
+		log.Infof("pve: guest has no cloud-init installed; skipping the wait")
+		return nil
+	case "0":
+		log.Infof("pve: cloud-init finished successfully")
+		return nil
+	case "2":
+		log.Warnf("pve: cloud-init finished with recoverable errors — the node should still work, but check this first if it misbehaves: %s", detail)
+		return nil
+	default:
+		return fmt.Errorf("pve: cloud-init failed in the guest (exit %s): %s", code, detail)
+	}
+}
+
+// parseCloudInitResult pulls the value out of the `pve-cloudinit-result=` line
+// the script emits.
+func parseCloudInitResult(out string) (string, bool) {
+	const marker = "pve-cloudinit-result="
+	idx := strings.Index(out, marker)
+	if idx < 0 {
+		return "", false
+	}
+	rest := out[idx+len(marker):]
+	if cut := strings.IndexAny(rest, " \t\r\n"); cut >= 0 {
+		rest = rest[:cut]
+	}
+	rest = strings.TrimSpace(rest)
+	if rest == "absent" {
+		return rest, true
+	}
+	if _, err := strconv.Atoi(rest); err != nil {
+		return "", false
+	}
+	return rest, true
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -91,6 +92,8 @@ type Driver struct {
 	TemplateTag      string
 	TemplateMatch    string
 	LinkedClone      bool
+	CloneStorage     string
+	CloneFormat      string
 	Tags             string
 	Description      string
 	Pool             string
@@ -230,6 +233,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "pve-linked-clone",
 			EnvVar: "PVE_LINKED_CLONE",
 			Usage:  "Clone the template as a linked clone instead of a full clone. Much faster and lighter on storage I/O when several machines clone at once, but every linked clone stays dependent on the template's disk for as long as it exists (the template can never be deleted or modified while one remains), and not every storage backend supports it",
+		},
+		mcnflag.StringFlag{
+			Name:   "pve-clone-storage",
+			EnvVar: "PVE_CLONE_STORAGE",
+			Usage:  "PVE storage id the clone's disks are created on, e.g. local-lvm or ceph-rbd. Empty puts them on the template's own storage, which pins every pool cloning that template to wherever the template happens to live. Full clones only — rejected together with pve-linked-clone",
+		},
+		mcnflag.StringFlag{
+			Name:   "pve-clone-format",
+			EnvVar: "PVE_CLONE_FORMAT",
+			Usage:  "Disk format for the clone: raw, qcow2 or vmdk. Empty uses the storage's default, which is almost always right — the format is only selectable on file-based storages (dir, NFS, CIFS), and block backends (LVM, ZFS, Ceph RBD) reject anything but their own. Full clones only",
 		},
 		mcnflag.StringFlag{
 			Name:   "pve-vm-name-prefix",
@@ -455,6 +468,8 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.TemplateMatch = defaultTemplateMatch
 	}
 	d.LinkedClone = flags.Bool("pve-linked-clone")
+	d.CloneStorage = strings.TrimSpace(flags.String("pve-clone-storage"))
+	d.CloneFormat = strings.ToLower(strings.TrimSpace(flags.String("pve-clone-format")))
 	d.Tags = strings.TrimSpace(flags.String("pve-tags"))
 	d.Description = strings.TrimSpace(flags.String("pve-description"))
 	d.Pool = strings.TrimSpace(flags.String("pve-pool"))
@@ -554,6 +569,9 @@ func (d *Driver) PreCreateCheck() error {
 		return errors.New("pve: --pve-api-token-secret is required")
 	}
 	if err := d.validateTemplateSelection(); err != nil {
+		return err
+	}
+	if err := d.validateCloneTarget(); err != nil {
 		return err
 	}
 	if err := d.validateVMNamePrefix(); err != nil {
@@ -867,9 +885,11 @@ func (d *Driver) cloneFromTemplate(ctx context.Context, vmName string) (int, err
 		return 0, err
 	}
 	opts := proxmox.CloneOptions{
-		Name:   vmName,
-		Linked: d.LinkedClone,
-		Pool:   d.Pool,
+		Name:    vmName,
+		Linked:  d.LinkedClone,
+		Pool:    d.Pool,
+		Storage: d.CloneStorage,
+		Format:  d.CloneFormat,
 	}
 	if d.VMID != 0 || d.VMIDRange == "" {
 		opts.NewID = d.VMID
@@ -996,6 +1016,31 @@ func (d *Driver) validateTemplateSelection() error {
 	case proxmox.MatchSubset, proxmox.MatchExact:
 	default:
 		return fmt.Errorf("pve: --pve-template-tag-match %q is not valid; use %q or %q", d.TemplateMatch, proxmox.MatchSubset, proxmox.MatchExact)
+	}
+	return nil
+}
+
+// validateCloneTarget checks the clone's destination storage and disk format.
+//
+// Both are full-clone-only in PVE: a linked clone is by definition an overlay
+// on the template's own disk, so there is no second storage for it to land on
+// and no format to choose. PVE rejects the combination itself, but with an
+// error that names the API parameter rather than the flag the operator set,
+// so it is caught here instead.
+func (d *Driver) validateCloneTarget() error {
+	if !d.LinkedClone {
+		if d.CloneFormat != "" && !slices.Contains(proxmox.CloneFormats, d.CloneFormat) {
+			return fmt.Errorf("pve: --pve-clone-format %q is not valid; use one of %s (or leave it empty to take the storage's default, which is what block storages like LVM, ZFS and Ceph RBD require)",
+				d.CloneFormat, strings.Join(proxmox.CloneFormats, ", "))
+		}
+		return nil
+	}
+	if d.CloneStorage != "" {
+		return fmt.Errorf("pve: --pve-clone-storage %q cannot be combined with --pve-linked-clone: a linked clone is an overlay on the template's own disk and always lives on the template's storage. Drop one of the two — a full clone onto a different storage is exactly how you move machines off the template's storage",
+			d.CloneStorage)
+	}
+	if d.CloneFormat != "" {
+		return fmt.Errorf("pve: --pve-clone-format %q cannot be combined with --pve-linked-clone: a linked clone inherits the template disk's format", d.CloneFormat)
 	}
 	return nil
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -61,6 +61,11 @@ const (
 	// working DNS and fail on what is really a transient condition — and a
 	// failed bootstrap gets the whole machine deleted and recreated.
 	defaultProvisionDelay = 30 * time.Second
+	// defaultTemplateMatch is the tag-matching policy for --pve-template-tag.
+	// Subset is the useful default: an image template usually carries build
+	// metadata tags (distro, date) alongside the one naming its role, and
+	// requiring the operator to list all of them would defeat the point.
+	defaultTemplateMatch = string(proxmox.MatchSubset)
 )
 
 // Driver is the libmachine Driver implementation backed by Proxmox VE.
@@ -77,6 +82,8 @@ type Driver struct {
 	VMID             int
 	VMIDRange        string
 	TemplateVMID     int
+	TemplateTag      string
+	TemplateMatch    string
 	LinkedClone      bool
 	Tags             string
 	Description      string
@@ -139,6 +146,7 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 		AgentTimeout:     defaultAgentTimeout,
 		DiskSetupTimeout: defaultDiskSetupTimeout,
 		ProvisionDelay:   defaultProvisionDelay,
+		TemplateMatch:    defaultTemplateMatch,
 	}
 }
 
@@ -196,8 +204,19 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		mcnflag.IntFlag{
 			Name:   "pve-template-vmid",
 			EnvVar: "PVE_TEMPLATE_VMID",
-			Usage:  "Existing PVE VM template VMID used to clone new VMs from",
+			Usage:  "Existing PVE VM template VMID used to clone new VMs from. Mutually exclusive with pve-template-tag",
 			Value:  0,
+		},
+		mcnflag.StringFlag{
+			Name:   "pve-template-tag",
+			EnvVar: "PVE_TEMPLATE_TAG",
+			Usage:  "Select the template to clone by PVE tag instead of by VMID, e.g. rancher-node. Comma-separated tags must all be present. Exactly one template must match, so a rebuilt image is rolled out by moving the tag rather than by editing every machine pool. Mutually exclusive with pve-template-vmid",
+		},
+		mcnflag.StringFlag{
+			Name:   "pve-template-tag-match",
+			EnvVar: "PVE_TEMPLATE_TAG_MATCH",
+			Usage:  "How pve-template-tag matches: subset (default, the template carries at least the given tags) or exact (the template's tags are exactly the given ones)",
+			Value:  defaultTemplateMatch,
 		},
 		mcnflag.BoolFlag{
 			Name:   "pve-linked-clone",
@@ -416,6 +435,11 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.VMID = flags.Int("pve-vmid")
 	d.VMIDRange = strings.TrimSpace(flags.String("pve-vmid-range"))
 	d.TemplateVMID = flags.Int("pve-template-vmid")
+	d.TemplateTag = strings.TrimSpace(flags.String("pve-template-tag"))
+	d.TemplateMatch = strings.ToLower(strings.TrimSpace(flags.String("pve-template-tag-match")))
+	if d.TemplateMatch == "" {
+		d.TemplateMatch = defaultTemplateMatch
+	}
 	d.LinkedClone = flags.Bool("pve-linked-clone")
 	d.Tags = strings.TrimSpace(flags.String("pve-tags"))
 	d.Description = strings.TrimSpace(flags.String("pve-description"))
@@ -508,8 +532,8 @@ func (d *Driver) PreCreateCheck() error {
 	if d.APITokenSecret == "" {
 		return errors.New("pve: --pve-api-token-secret is required")
 	}
-	if d.TemplateVMID == 0 {
-		return errors.New("pve: --pve-template-vmid is required to clone a VM")
+	if err := d.validateTemplateSelection(); err != nil {
+		return err
 	}
 	if err := d.validateVMNamePrefix(); err != nil {
 		return err
@@ -624,10 +648,18 @@ func (d *Driver) Create() error {
 	if err := d.init(); err != nil {
 		return err
 	}
-	if d.TemplateVMID == 0 {
-		return errors.New("pve: --pve-template-vmid is required to clone a VM")
+	if err := d.validateTemplateSelection(); err != nil {
+		return err
 	}
 	ctx := context.Background()
+
+	// Tag resolution happens here rather than in PreCreateCheck so every
+	// machine in a pool resolves against the cluster as it is at its own
+	// create time: retagging a rebuilt image then rolls new machines onto it
+	// without touching the machine pool.
+	if err := d.resolveTemplateVMID(ctx); err != nil {
+		return err
+	}
 
 	vmName := d.resolveVMName()
 
@@ -867,6 +899,58 @@ func (d *Driver) resolveVMName() string {
 		return d.MachineName
 	}
 	return prefix + "-" + d.MachineName
+}
+
+// resolveTemplateVMID fills in d.TemplateVMID from --pve-template-tag when a
+// VMID was not given directly. It is a no-op when the VMID is already known.
+//
+// The resolved id is only used for this Create call and deliberately not
+// treated as a permanent binding: a later machine in the same pool resolves
+// the tag again, so a template rebuilt and retagged mid-scale-up is picked up
+// by the machines created after it.
+func (d *Driver) resolveTemplateVMID(ctx context.Context) error {
+	if d.TemplateVMID != 0 || d.TemplateTag == "" {
+		return nil
+	}
+	tags := strings.Split(d.TemplateTag, ",")
+	found, err := d.client.FindTemplateByTags(ctx, tags, proxmox.TemplateMatch(d.TemplateMatch))
+	if err != nil {
+		return err
+	}
+	d.TemplateVMID = found.VMID
+	log.Infof("pve: template tag %q (%s match) resolved to VMID %d (%q) on node %s",
+		d.TemplateTag, d.TemplateMatch, found.VMID, found.Name, found.Node)
+	return nil
+}
+
+// validateTemplateSelection checks that exactly one way of naming the template
+// is configured, and that the tag list and match policy are usable. It does not
+// hit the API — resolving the tag to a VMID happens in Create, against the live
+// cluster.
+func (d *Driver) validateTemplateSelection() error {
+	switch {
+	case d.TemplateVMID == 0 && d.TemplateTag == "":
+		return errors.New("pve: one of --pve-template-vmid or --pve-template-tag is required to clone a VM")
+	case d.TemplateVMID != 0 && d.TemplateTag != "":
+		return fmt.Errorf("pve: --pve-template-vmid %d and --pve-template-tag %q are mutually exclusive; an explicit VMID already names the template, and honouring both would silently ignore one of them", d.TemplateVMID, d.TemplateTag)
+	}
+	if d.TemplateTag == "" {
+		return nil
+	}
+	tags, err := normalizeTagList("--pve-template-tag", d.TemplateTag)
+	if err != nil {
+		return err
+	}
+	if len(tags) == 0 {
+		return fmt.Errorf("pve: --pve-template-tag %q contains no usable tag", d.TemplateTag)
+	}
+	d.TemplateTag = strings.Join(tags, ",")
+	switch proxmox.TemplateMatch(d.TemplateMatch) {
+	case proxmox.MatchSubset, proxmox.MatchExact:
+	default:
+		return fmt.Errorf("pve: --pve-template-tag-match %q is not valid; use %q or %q", d.TemplateMatch, proxmox.MatchSubset, proxmox.MatchExact)
+	}
+	return nil
 }
 
 // resolveDescription returns the text written to the VM's Notes field.

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -79,6 +79,7 @@ type Driver struct {
 	TemplateVMID     int
 	LinkedClone      bool
 	Tags             string
+	Description      string
 	Pool             string
 	VMNamePrefix     string
 	Cores            int
@@ -212,6 +213,11 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Name:   "pve-tags",
 			EnvVar: "PVE_TAGS",
 			Usage:  "Comma-separated PVE tags applied to the created VM, e.g. rancher,prod. Purely informational to PVE — lets a VM this driver created be identified and filtered in the PVE UI. Lowercase letters, digits, and _ + . - only",
+		},
+		mcnflag.StringFlag{
+			Name:   "pve-description",
+			EnvVar: "PVE_DESCRIPTION",
+			Usage:  "Text written to the VM's Notes field in PVE. Empty writes a default noting the driver, the machine name and the template it was cloned from — a clone would otherwise inherit the template's own notes, which describe the template rather than the machine",
 		},
 		mcnflag.StringFlag{
 			Name:   "pve-pool",
@@ -412,6 +418,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.TemplateVMID = flags.Int("pve-template-vmid")
 	d.LinkedClone = flags.Bool("pve-linked-clone")
 	d.Tags = strings.TrimSpace(flags.String("pve-tags"))
+	d.Description = strings.TrimSpace(flags.String("pve-description"))
 	d.Pool = strings.TrimSpace(flags.String("pve-pool"))
 	d.VMNamePrefix = strings.TrimSpace(flags.String("pve-vm-name-prefix"))
 	d.Cores = flags.Int("pve-cores")
@@ -678,6 +685,7 @@ func (d *Driver) finalizeCreate(ctx context.Context, vmName string) error {
 		Memory:       uint32(d.MemoryMB),
 		Onboot:       &onboot,
 		Tags:         d.Tags,
+		Description:  d.resolveDescription(),
 		CloudInit:    d.CloudInit,
 		IPConfig:     ipConfig,
 		Nameserver:   d.Nameservers,
@@ -859,6 +867,21 @@ func (d *Driver) resolveVMName() string {
 		return d.MachineName
 	}
 	return prefix + "-" + d.MachineName
+}
+
+// resolveDescription returns the text written to the VM's Notes field.
+//
+// A clone inherits the template's own notes, which describe the template and
+// are actively misleading on a machine — so the default is not "leave it
+// alone" but a short provenance line. Somebody looking at an unfamiliar VM in
+// the PVE UI can then tell what created it and what it belongs to without
+// cross-referencing Rancher.
+func (d *Driver) resolveDescription() string {
+	if d.Description != "" {
+		return d.Description
+	}
+	return fmt.Sprintf("Rancher machine %q, cloned from template %d by docker-machine-driver-pve. Managed by Rancher — changes made here may be overwritten or lost when the machine is replaced.",
+		d.MachineName, d.TemplateVMID)
 }
 
 // validateVMNamePrefix rejects a prefix that would produce a VM name PVE

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -61,6 +61,12 @@ const (
 	// working DNS and fail on what is really a transient condition — and a
 	// failed bootstrap gets the whole machine deleted and recreated.
 	defaultProvisionDelay = 30 * time.Second
+	// defaultCloudInitTimeout bounds the wait for cloud-init to finish inside
+	// the guest. It is the readiness signal --pve-provision-delay only
+	// approximates: cloud-init reports its own completion, so the driver can
+	// wait for the real thing instead of guessing at a duration. Generous
+	// because a first boot runs package installs and disk growth.
+	defaultCloudInitTimeout = 5 * time.Minute
 	// defaultTemplateMatch is the tag-matching policy for --pve-template-tag.
 	// Subset is the useful default: an image template usually carries build
 	// metadata tags (distro, date) alongside the one naming its role, and
@@ -116,6 +122,7 @@ type Driver struct {
 	SSHKeys          string
 	Onboot           bool
 	AgentTimeout     time.Duration
+	CloudInitTimeout time.Duration
 	ProvisionDelay   time.Duration
 	KeepOnFailure    bool
 	SkipPermCheck    bool
@@ -144,6 +151,7 @@ func NewDriver(hostName, storePath string) drivers.Driver {
 		IPMode:           string(ipModeDHCP),
 		Onboot:           false,
 		AgentTimeout:     defaultAgentTimeout,
+		CloudInitTimeout: defaultCloudInitTimeout,
 		DiskSetupTimeout: defaultDiskSetupTimeout,
 		ProvisionDelay:   defaultProvisionDelay,
 		TemplateMatch:    defaultTemplateMatch,
@@ -330,6 +338,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Value:  int(defaultAgentTimeout / time.Second),
 		},
 		mcnflag.IntFlag{
+			Name:   "pve-cloudinit-timeout",
+			EnvVar: "PVE_CLOUDINIT_TIMEOUT",
+			Usage:  "Seconds to wait for cloud-init to finish inside the guest before handing the machine to Rancher. This is the real readiness signal that pve-provision-delay only approximates, so with it enabled the delay can usually be lowered or set to 0. Set to 0 to skip the wait entirely (guests without cloud-init are detected and skipped automatically)",
+			Value:  int(defaultCloudInitTimeout / time.Second),
+		},
+		mcnflag.IntFlag{
 			Name:   "pve-provision-delay",
 			EnvVar: "PVE_PROVISION_DELAY",
 			Usage:  "Seconds to wait after the VM is up before handing it back to Rancher for provisioning. Defaults to 30 because several cloud images accept SSH before cloud-init has finished configuring DNS and the default route, which makes Rancher's first bootstrap command fail against a half-ready guest. Set to 0 to hand it back immediately",
@@ -495,6 +509,13 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		d.AgentTimeout = time.Duration(timeoutSec) * time.Second
 	} else {
 		d.AgentTimeout = defaultAgentTimeout
+	}
+	// 0 is meaningful (skip the wait), so only a negative value falls back to
+	// the default.
+	if ciSec := flags.Int("pve-cloudinit-timeout"); ciSec >= 0 {
+		d.CloudInitTimeout = time.Duration(ciSec) * time.Second
+	} else {
+		d.CloudInitTimeout = defaultCloudInitTimeout
 	}
 	if setupSec := flags.Int("pve-disk-setup-timeout"); setupSec > 0 {
 		d.DiskSetupTimeout = time.Duration(setupSec) * time.Second
@@ -784,14 +805,25 @@ func (d *Driver) finalizeCreate(ctx context.Context, vmName string) error {
 		log.Infof("pve: VM %d uses MAC %s on %s", d.VMID, mac, d.NetDevice)
 	}
 
-	// Data disks are set up over SSH, so the address has to be resolved here
-	// rather than left to the GetIP call libmachine makes after Create.
-	if len(d.DataDisks) > 0 {
+	// Both the cloud-init wait and data disk setup happen over SSH, so the
+	// address has to be resolved here rather than left to the GetIP call
+	// libmachine makes after Create.
+	if len(d.DataDisks) > 0 || d.CloudInitTimeout > 0 {
 		ip, err := d.waitUntilGuestIP(ctx)
 		if err != nil {
 			return err
 		}
 		d.IPAddress = ip
+	}
+
+	// Before the disks, not after: cloud-init can still be growing the root
+	// filesystem, rewriting fstab or restarting the network while the driver
+	// would otherwise be partitioning and mounting alongside it.
+	if err := d.waitForCloudInit(); err != nil {
+		return err
+	}
+
+	if len(d.DataDisks) > 0 {
 		if err := d.setupGuestDisks(attached); err != nil {
 			return err
 		}
@@ -923,6 +955,21 @@ func (d *Driver) resolveTemplateVMID(ctx context.Context) error {
 	return nil
 }
 
+// resolveDescription returns the text written to the VM's Notes field.
+//
+// A clone inherits the template's own notes, which describe the template and
+// are actively misleading on a machine — so the default is not "leave it
+// alone" but a short provenance line. Somebody looking at an unfamiliar VM in
+// the PVE UI can then tell what created it and what it belongs to without
+// cross-referencing Rancher.
+func (d *Driver) resolveDescription() string {
+	if d.Description != "" {
+		return d.Description
+	}
+	return fmt.Sprintf("Rancher machine %q, cloned from template %d by docker-machine-driver-pve. Managed by Rancher — changes made here may be overwritten or lost when the machine is replaced.",
+		d.MachineName, d.TemplateVMID)
+}
+
 // validateTemplateSelection checks that exactly one way of naming the template
 // is configured, and that the tag list and match policy are usable. It does not
 // hit the API — resolving the tag to a VMID happens in Create, against the live
@@ -951,21 +998,6 @@ func (d *Driver) validateTemplateSelection() error {
 		return fmt.Errorf("pve: --pve-template-tag-match %q is not valid; use %q or %q", d.TemplateMatch, proxmox.MatchSubset, proxmox.MatchExact)
 	}
 	return nil
-}
-
-// resolveDescription returns the text written to the VM's Notes field.
-//
-// A clone inherits the template's own notes, which describe the template and
-// are actively misleading on a machine — so the default is not "leave it
-// alone" but a short provenance line. Somebody looking at an unfamiliar VM in
-// the PVE UI can then tell what created it and what it belongs to without
-// cross-referencing Rancher.
-func (d *Driver) resolveDescription() string {
-	if d.Description != "" {
-		return d.Description
-	}
-	return fmt.Sprintf("Rancher machine %q, cloned from template %d by docker-machine-driver-pve. Managed by Rancher — changes made here may be overwritten or lost when the machine is replaced.",
-		d.MachineName, d.TemplateVMID)
 }
 
 // validateVMNamePrefix rejects a prefix that would produce a VM name PVE

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -364,6 +364,8 @@ func TestCreateFlagsDeriveExpectedFieldNames(t *testing.T) {
 	for _, want := range []string{
 		"templateVmid", "dataDisk", "netBridge", "cloudinit",
 		"sshUser", "sshPort", "vmNamePrefix", "bootDiskSize",
+		"templateTag", "templateTagMatch", "cloneStorage", "cloneFormat",
+		"description", "cloudinitTimeout",
 	} {
 		if !got[want] {
 			t.Errorf("no flag derives the machine-config field %q that the UI extension binds to", want)

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -604,23 +604,6 @@ func TestNormalizeTags(t *testing.T) {
 	}
 }
 
-func TestResolveDescription(t *testing.T) {
-	d := &Driver{BaseDriver: &drivers.BaseDriver{MachineName: "pool-abc"}, TemplateVMID: 9000}
-	got := d.resolveDescription()
-	// The default exists to stop the clone from carrying the template's own
-	// notes, so it has to name this machine and where it came from.
-	for _, want := range []string{"pool-abc", "9000", "docker-machine-driver-pve"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("resolveDescription() = %q, want it to mention %q", got, want)
-		}
-	}
-
-	d.Description = "custom notes"
-	if got := d.resolveDescription(); got != "custom notes" {
-		t.Errorf("resolveDescription() = %q, want the explicit --pve-description value", got)
-	}
-}
-
 func TestValidateTemplateSelection(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -672,5 +655,75 @@ func TestValidateTemplateSelectionNormalizesTags(t *testing.T) {
 	}
 	if d.TemplateTag != "rancher,node" {
 		t.Errorf("TemplateTag = %q, want %q (lowercased, trimmed, deduped)", d.TemplateTag, "rancher,node")
+	}
+}
+
+func TestResolveDescription(t *testing.T) {
+	d := &Driver{BaseDriver: &drivers.BaseDriver{MachineName: "pool-abc"}, TemplateVMID: 9000}
+	got := d.resolveDescription()
+	// The default exists to stop the clone from carrying the template's own
+	// notes, so it has to name this machine and where it came from.
+	for _, want := range []string{"pool-abc", "9000", "docker-machine-driver-pve"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("resolveDescription() = %q, want it to mention %q", got, want)
+		}
+	}
+
+	d.Description = "custom notes"
+	if got := d.resolveDescription(); got != "custom notes" {
+		t.Errorf("resolveDescription() = %q, want the explicit --pve-description value", got)
+	}
+}
+
+func TestParseCloudInitResult(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"pve-cloudinit-result=0\nstatus: done", "0", true},
+		{"pve-cloudinit-result=2 status: degraded done", "2", true},
+		{"pve-cloudinit-result=absent", "absent", true},
+		{"pve-cloudinit-result=1", "1", true},
+		{"some unrelated banner text", "", false},
+		{"pve-cloudinit-result=nonsense", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := parseCloudInitResult(tt.in)
+		if ok != tt.ok || got != tt.want {
+			t.Errorf("parseCloudInitResult(%q) = (%q, %v), want (%q, %v)", tt.in, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+func TestInterpretCloudInitResult(t *testing.T) {
+	// Only a genuine cloud-init failure blocks the machine. Recoverable
+	// errors, a guest without cloud-init and unparseable output all continue:
+	// failing there would delete a node that is very likely fine.
+	tests := []struct {
+		name    string
+		out     string
+		wantErr bool
+	}{
+		{"success", "pve-cloudinit-result=0", false},
+		{"recoverable errors", "pve-cloudinit-result=2 status: degraded done", false},
+		{"no cloud-init in the guest", "pve-cloudinit-result=absent", false},
+		{"unreadable output", "banner nonsense", false},
+		{"failure", "pve-cloudinit-result=1 status: error", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := interpretCloudInitResult(tt.out)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("interpretCloudInitResult(%q) = %v, wantErr %v", tt.out, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCloudInitTimeoutDefaultsToNonZero(t *testing.T) {
+	d := NewDriver("machine", "/tmp").(*Driver)
+	if d.CloudInitTimeout != defaultCloudInitTimeout {
+		t.Errorf("CloudInitTimeout = %s, want %s", d.CloudInitTimeout, defaultCloudInitTimeout)
 	}
 }

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -727,3 +727,46 @@ func TestCloudInitTimeoutDefaultsToNonZero(t *testing.T) {
 		t.Errorf("CloudInitTimeout = %s, want %s", d.CloudInitTimeout, defaultCloudInitTimeout)
 	}
 }
+
+func TestValidateCloneTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Driver)
+		wantErr string
+	}{
+		{"nothing set is fine", func(d *Driver) {}, ""},
+		{"storage on a full clone", func(d *Driver) { d.CloneStorage = "ceph-rbd" }, ""},
+		{"valid format", func(d *Driver) { d.CloneFormat = "qcow2" }, ""},
+		{"invalid format", func(d *Driver) { d.CloneFormat = "vhdx" }, "--pve-clone-format"},
+		// Both are full-clone-only in PVE: a linked clone is an overlay on the
+		// template's own disk, so there is no second storage or format to pick.
+		{"storage with linked clone", func(d *Driver) {
+			d.LinkedClone = true
+			d.CloneStorage = "ceph-rbd"
+		}, "--pve-clone-storage"},
+		{"format with linked clone", func(d *Driver) {
+			d.LinkedClone = true
+			d.CloneFormat = "qcow2"
+		}, "--pve-clone-format"},
+		{"linked clone alone is fine", func(d *Driver) { d.LinkedClone = true }, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Driver{}
+			tt.mutate(d)
+			err := d.validateCloneTarget()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateCloneTarget() returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateCloneTarget() = nil, want an error mentioning %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateCloneTarget() error = %q, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -603,3 +603,20 @@ func TestNormalizeTags(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveDescription(t *testing.T) {
+	d := &Driver{BaseDriver: &drivers.BaseDriver{MachineName: "pool-abc"}, TemplateVMID: 9000}
+	got := d.resolveDescription()
+	// The default exists to stop the clone from carrying the template's own
+	// notes, so it has to name this machine and where it came from.
+	for _, want := range []string{"pool-abc", "9000", "docker-machine-driver-pve"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("resolveDescription() = %q, want it to mention %q", got, want)
+		}
+	}
+
+	d.Description = "custom notes"
+	if got := d.resolveDescription(); got != "custom notes" {
+		t.Errorf("resolveDescription() = %q, want the explicit --pve-description value", got)
+	}
+}

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -620,3 +620,57 @@ func TestResolveDescription(t *testing.T) {
 		t.Errorf("resolveDescription() = %q, want the explicit --pve-description value", got)
 	}
 }
+
+func TestValidateTemplateSelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Driver)
+		wantErr string
+	}{
+		{"neither vmid nor tag", func(d *Driver) {}, "--pve-template-tag"},
+		{"both are mutually exclusive", func(d *Driver) {
+			d.TemplateVMID = 9000
+			d.TemplateTag = "rancher"
+		}, "mutually exclusive"},
+		{"vmid alone is fine", func(d *Driver) { d.TemplateVMID = 9000 }, ""},
+		{"tag alone is fine", func(d *Driver) { d.TemplateTag = "rancher" }, ""},
+		{"invalid tag", func(d *Driver) { d.TemplateTag = "Not A Tag!" }, "not a valid PVE tag"},
+		{"invalid match policy", func(d *Driver) {
+			d.TemplateTag = "rancher"
+			d.TemplateMatch = "fuzzy"
+		}, "--pve-template-tag-match"},
+		{"exact match policy is accepted", func(d *Driver) {
+			d.TemplateTag = "rancher"
+			d.TemplateMatch = "exact"
+		}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Driver{TemplateMatch: defaultTemplateMatch}
+			tt.mutate(d)
+			err := d.validateTemplateSelection()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateTemplateSelection() returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateTemplateSelection() = nil, want an error mentioning %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateTemplateSelection() error = %q, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateTemplateSelectionNormalizesTags(t *testing.T) {
+	d := &Driver{TemplateTag: " Rancher , NODE ,rancher", TemplateMatch: defaultTemplateMatch}
+	if err := d.validateTemplateSelection(); err != nil {
+		t.Fatalf("validateTemplateSelection() returned error: %v", err)
+	}
+	if d.TemplateTag != "rancher,node" {
+		t.Errorf("TemplateTag = %q, want %q (lowercased, trimmed, deduped)", d.TemplateTag, "rancher,node")
+	}
+}

--- a/pkg/driver/tags.go
+++ b/pkg/driver/tags.go
@@ -21,6 +21,17 @@ const tagSeparator = ";"
 // (possibly differing only in case) is a harmless typo, not a config error
 // worth failing PreCreateCheck over.
 func normalizeTags(s string) (string, error) {
+	tags, err := normalizeTagList("--pve-tags", s)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join(tags, tagSeparator), nil
+}
+
+// normalizeTagList parses a comma-separated tag list into lowercase, deduped
+// tags, validating each one. flag names the flag the list came from so the
+// error points at the field the operator actually typed into.
+func normalizeTagList(flag, s string) ([]string, error) {
 	fields := strings.Split(s, ",")
 	tags := make([]string, 0, len(fields))
 	seen := make(map[string]bool, len(fields))
@@ -30,7 +41,7 @@ func normalizeTags(s string) (string, error) {
 			continue
 		}
 		if !pveTagPattern.MatchString(tag) {
-			return "", fmt.Errorf("pve: --pve-tags %q is not a valid PVE tag; use lowercase letters, digits, and _ + . -, starting with a letter, digit or underscore", tag)
+			return nil, fmt.Errorf("pve: %s %q is not a valid PVE tag; use lowercase letters, digits, and _ + . -, starting with a letter, digit or underscore", flag, tag)
 		}
 		if seen[tag] {
 			continue
@@ -38,5 +49,5 @@ func normalizeTags(s string) (string, error) {
 		seen[tag] = true
 		tags = append(tags, tag)
 	}
-	return strings.Join(tags, tagSeparator), nil
+	return tags, nil
 }

--- a/pkg/proxmox/client.go
+++ b/pkg/proxmox/client.go
@@ -369,6 +369,48 @@ type CloneOptions struct {
 	// only ever act on VMs inside the pool, and every VM this driver
 	// creates lands there from the moment it exists.
 	Pool string
+	// Storage is the PVE storage id the clone's disks are created on. Empty
+	// inherits the template's own storage, which is PVE's behaviour and was
+	// this driver's only option before — it pins every machine pool cloning a
+	// given template to wherever that template happens to live.
+	//
+	// Full clones only: PVE rejects it outright for a linked clone, whose
+	// whole point is to reference the template's disk in place.
+	Storage string
+	// Format is the disk format for the clone (raw, qcow2, vmdk). Empty uses
+	// the storage's default, which is what almost every setup wants: the
+	// format is only selectable on file-based storages (dir, NFS, CIFS), and
+	// block backends (LVM, ZFS, Ceph RBD) reject anything but their own.
+	//
+	// Full clones only, same as Storage.
+	Format string
+}
+
+// CloneFormats are the disk formats PVE accepts for a full clone.
+var CloneFormats = []string{"raw", "qcow2", "vmdk"}
+
+// cloneParams renders the PVE clone request for opts.
+//
+// Storage and Format are full-clone-only in PVE and are dropped for a linked
+// clone rather than passed through. Callers validate the combination earlier
+// so the operator sees a message naming the flag they set, but the request
+// itself must be correct however the client is called.
+func cloneParams(opts CloneOptions) *proxmox.VirtualMachineCloneOptions {
+	full := uint8(1)
+	if opts.Linked {
+		full = 0
+	}
+	params := &proxmox.VirtualMachineCloneOptions{
+		NewID: opts.NewID,
+		Name:  opts.Name,
+		Full:  full,
+		Pool:  opts.Pool,
+	}
+	if !opts.Linked {
+		params.Storage = opts.Storage
+		params.Format = opts.Format
+	}
+	return params
 }
 
 // CloneFromTemplate clones the given template VMID into a new VM according
@@ -400,16 +442,7 @@ func (c *Client) CloneFromTemplate(ctx context.Context, templateVMID int, opts C
 		return 0, err
 	}
 
-	full := uint8(1)
-	if opts.Linked {
-		full = 0
-	}
-	params := &proxmox.VirtualMachineCloneOptions{
-		NewID: opts.NewID,
-		Name:  opts.Name,
-		Full:  full,
-		Pool:  opts.Pool,
-	}
+	params := cloneParams(opts)
 	if target != templateNode {
 		params.Target = target
 	}

--- a/pkg/proxmox/client.go
+++ b/pkg/proxmox/client.go
@@ -352,6 +352,9 @@ func (c *Client) Configure(ctx context.Context, vmid int, opts VMOptions) error 
 	if opts.Tags != "" {
 		options = append(options, proxmox.VirtualMachineOption{Name: "tags", Value: opts.Tags})
 	}
+	if opts.Description != "" {
+		options = append(options, proxmox.VirtualMachineOption{Name: "description", Value: opts.Description})
+	}
 	if opts.CloudInit {
 		if opts.IPConfig != "" {
 			options = append(options, proxmox.VirtualMachineOption{Name: "ipconfig0", Value: opts.IPConfig})
@@ -764,7 +767,13 @@ type VMOptions struct {
 	// Tags is PVE's semicolon-separated `tags` config value. Purely
 	// informational to PVE itself, but it is how a VM created by this driver
 	// is identified/filtered in the PVE UI without opening it.
-	Tags         string
+	Tags string
+	// Description is PVE's free-text `description` config value, rendered as
+	// the Notes panel in the PVE UI. A clone inherits the template's notes,
+	// which describe the template rather than the machine, so the driver
+	// always overwrites it with something that identifies who created this VM
+	// and what it belongs to.
+	Description  string
 	CloudInit    bool
 	IPConfig     string
 	Nameserver   string

--- a/pkg/proxmox/client.go
+++ b/pkg/proxmox/client.go
@@ -240,6 +240,112 @@ func (c *Client) nodeOf(ctx context.Context, vmid int) (string, error) {
 	return "", fmt.Errorf("proxmox: VMID %d not found anywhere in the cluster", vmid)
 }
 
+// TemplateMatch selects how FindTemplateByTags compares a template's tags
+// against the requested ones.
+type TemplateMatch string
+
+const (
+	// MatchSubset accepts a template that carries every requested tag,
+	// whatever else it also carries.
+	MatchSubset TemplateMatch = "subset"
+	// MatchExact accepts only a template whose tag set is exactly the
+	// requested one.
+	MatchExact TemplateMatch = "exact"
+)
+
+// FoundTemplate is a template resolved by tag, carrying enough context for
+// the caller to log which one it picked.
+type FoundTemplate struct {
+	VMID int
+	Name string
+	Node string
+	Tags []string
+}
+
+// FindTemplateByTags returns the VM template matching the given tags.
+//
+// It exists so a machine pool can name an *image* rather than a VMID:
+// rebuilding the template and moving the tag to the new one is then enough to
+// roll new machines onto a new image, with no machine-pool edit and no chance
+// of a stale VMID pointing at a template that was deleted.
+//
+// Ambiguity is an error rather than a silent choice. Two templates carrying
+// the same tag is exactly what a half-finished image rollout looks like, and
+// picking one (the lowest VMID, say) would provision half a machine pool from
+// each. The error names both so the operator can retag the loser.
+func (c *Client) FindTemplateByTags(ctx context.Context, tags []string, match TemplateMatch) (FoundTemplate, error) {
+	if len(tags) == 0 {
+		return FoundTemplate{}, errors.New("proxmox: no template tags given")
+	}
+	resources, err := c.clusterResources(ctx)
+	if err != nil {
+		return FoundTemplate{}, err
+	}
+	var found []FoundTemplate
+	for _, r := range resources {
+		// Template != 0 is what distinguishes a template from a plain VM; the
+		// type check keeps LXC templates carrying the same tag out of it.
+		if r.Type != "qemu" || r.Template == 0 {
+			continue
+		}
+		have := splitTags(r.Tags)
+		if !tagsMatch(have, tags, match) {
+			continue
+		}
+		found = append(found, FoundTemplate{
+			VMID: int(r.VMID),
+			Name: r.Name,
+			Node: r.Node,
+			Tags: have,
+		})
+	}
+	switch len(found) {
+	case 1:
+		return found[0], nil
+	case 0:
+		return FoundTemplate{}, fmt.Errorf("proxmox: no VM template matches tags %q (%s match); tag the template in the PVE UI, or check the API token can see it — a token with no privileges on the template's node simply gets an empty list rather than an error",
+			strings.Join(tags, ","), match)
+	default:
+		sort.Slice(found, func(i, j int) bool { return found[i].VMID < found[j].VMID })
+		var names []string
+		for _, f := range found {
+			names = append(names, fmt.Sprintf("%d (%s)", f.VMID, f.Name))
+		}
+		return FoundTemplate{}, fmt.Errorf("proxmox: tags %q (%s match) match %d templates: %s; a tag used for template selection must identify exactly one template, so remove it from all but the one you want",
+			strings.Join(tags, ","), match, len(found), strings.Join(names, ", "))
+	}
+}
+
+// splitTags parses a PVE `tags` value. PVE stores them semicolon-separated
+// but accepts commas on input and normalises them, so both are split here.
+func splitTags(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool { return r == ';' || r == ',' })
+	tags := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f = strings.ToLower(strings.TrimSpace(f)); f != "" {
+			tags = append(tags, f)
+		}
+	}
+	return tags
+}
+
+// tagsMatch reports whether have satisfies want under the given policy.
+func tagsMatch(have, want []string, match TemplateMatch) bool {
+	set := make(map[string]bool, len(have))
+	for _, t := range have {
+		set[t] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			return false
+		}
+	}
+	if match == MatchExact {
+		return len(set) == len(want)
+	}
+	return true
+}
+
 // CloneOptions configures a single template clone.
 type CloneOptions struct {
 	// NewID is the VMID to assign the clone. 0 lets Proxmox assign the next

--- a/pkg/proxmox/client_test.go
+++ b/pkg/proxmox/client_test.go
@@ -377,3 +377,39 @@ func TestTagsMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestCloneOptionsDropStorageAndFormatForLinkedClones(t *testing.T) {
+	// PVE rejects storage/format on a linked clone. The driver validates this
+	// first, but the client must not pass them on regardless of how it was
+	// called — a linked clone has no storage of its own to land on.
+	for _, tt := range []struct {
+		name   string
+		linked bool
+		want   string
+	}{
+		{"full clone keeps the storage", false, "ceph-rbd"},
+		{"linked clone drops it", true, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := CloneOptions{Linked: tt.linked, Storage: "ceph-rbd", Format: "qcow2"}
+			got := cloneParams(opts)
+			if got.Storage != tt.want {
+				t.Errorf("Storage = %q, want %q", got.Storage, tt.want)
+			}
+			wantFormat := "qcow2"
+			if tt.linked {
+				wantFormat = ""
+			}
+			if got.Format != wantFormat {
+				t.Errorf("Format = %q, want %q", got.Format, wantFormat)
+			}
+			wantFull := uint8(1)
+			if tt.linked {
+				wantFull = 0
+			}
+			if got.Full != wantFull {
+				t.Errorf("Full = %d, want %d", got.Full, wantFull)
+			}
+		})
+	}
+}

--- a/pkg/proxmox/client_test.go
+++ b/pkg/proxmox/client_test.go
@@ -327,3 +327,53 @@ func TestIsNotFound(t *testing.T) {
 type errString string
 
 func (e errString) Error() string { return string(e) }
+
+func TestSplitTags(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"rancher", []string{"rancher"}},
+		// PVE stores tags semicolon-separated but accepts commas on input.
+		{"rancher;node", []string{"rancher", "node"}},
+		{"rancher,node", []string{"rancher", "node"}},
+		{" Rancher ; NODE ", []string{"rancher", "node"}},
+		{";;rancher;;", []string{"rancher"}},
+	}
+	for _, tt := range tests {
+		got := splitTags(tt.in)
+		if len(got) != len(tt.want) {
+			t.Fatalf("splitTags(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("splitTags(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+func TestTagsMatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		have  []string
+		want  []string
+		match TemplateMatch
+		ok    bool
+	}{
+		{"subset: extra build tags are fine", []string{"rancher", "debian13", "2026-08"}, []string{"rancher"}, MatchSubset, true},
+		{"subset: all requested must be present", []string{"rancher"}, []string{"rancher", "gpu"}, MatchSubset, false},
+		{"subset: identical sets match", []string{"rancher"}, []string{"rancher"}, MatchSubset, true},
+		{"exact: extra tags disqualify", []string{"rancher", "debian13"}, []string{"rancher"}, MatchExact, false},
+		{"exact: identical sets match", []string{"rancher", "gpu"}, []string{"gpu", "rancher"}, MatchExact, true},
+		{"untagged template never matches", nil, []string{"rancher"}, MatchSubset, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tagsMatch(tt.have, tt.want, tt.match); got != tt.ok {
+				t.Errorf("tagsMatch(%v, %v, %q) = %v, want %v", tt.have, tt.want, tt.match, got, tt.ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces support for cloud-init readiness checks and expands template selection and cloning options in the Proxmox driver, along with comprehensive documentation updates. The most important changes are grouped below:

### Cloud-init readiness support

* Added a new `waitForCloudInit` method and supporting logic in `cloudinitwait.go` and `driver.go` to block provisioning until `cloud-init` finishes inside the guest, with configurable timeout via the new `pve-cloudinit-timeout` flag. This ensures machines are only handed to Rancher once fully initialized, reducing transient bootstrap failures. [[1]](diffhunk://#diff-61ee3aab08f47055e1c616f1ad759069ee05b1dc85b387f062bd0efae66be263R1-R136) [[2]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R65-R75) [[3]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R128) [[4]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R157-R160)
* Updated documentation in `docs/flags.md` and `docs/rancher-setup.md` to describe the new `pve-cloudinit-timeout` flag, its behavior, and recommended usage. [[1]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dR253) [[2]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dR262-R291) [[3]](diffhunk://#diff-6cb796d91a7cfef66b5bb91b96c2e4f9874ccd3fa153015300ed12d5aeeabe91L234-R240)

### Template selection and cloning enhancements

* Added support for selecting templates by tag (`pve-template-tag`) instead of VMID, with a configurable match policy (`pve-template-tag-match`), making image updates and pool management more flexible. [[1]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R92-R98) [[2]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dL35-R45) [[3]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dR66-R143) [[4]](diffhunk://#diff-6cb796d91a7cfef66b5bb91b96c2e4f9874ccd3fa153015300ed12d5aeeabe91L207-R216)
* Introduced new flags for controlling clone disk storage (`pve-clone-storage`) and format (`pve-clone-format`), allowing full clones to be placed on specific storage backends and formats. [[1]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R92-R98) [[2]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dL35-R45) [[3]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dR66-R143) [[4]](diffhunk://#diff-6cb796d91a7cfef66b5bb91b96c2e4f9874ccd3fa153015300ed12d5aeeabe91L207-R216)
* Added `pve-description` flag to customize the VM's Notes field at creation, improving traceability and UI clarity. [[1]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R92-R98) [[2]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dL35-R45) [[3]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dR66-R143) [[4]](diffhunk://#diff-6cb796d91a7cfef66b5bb91b96c2e4f9874ccd3fa153015300ed12d5aeeabe91L207-R216)

### Provisioning workflow adjustment

* Updated the documented and actual provisioning sequence so that the driver waits for cloud-init before formatting/mounting data disks, ensuring cloud-init has completed any disk or filesystem changes first.

### Codebase improvements

* Added new fields to the `Driver` struct and set sensible defaults for all new options, ensuring backward compatibility and ease of adoption. [[1]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R92-R98) [[2]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R128) [[3]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R157-R160)
* Minor import and constant additions to support new features. [[1]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R13) [[2]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R65-R75)

These changes make machine provisioning more robust, flexible, and user-friendly, especially in environments with varying image lifecycles and storage requirements.