### PR TITLE
ci: stop release runs from cancelling each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,30 @@ on:
     paths-ignore:
       - deploy/chart/**
   workflow_call:
+    inputs:
+      skip-cross-compile:
+        description: >-
+          Skip the cross-compile job. Set by release.yml: goreleaser rebuilds
+          every target minutes later, so `make dist` there is pure duplicate
+          work on the critical path of a release.
+        type: boolean
+        default: false
 
+# The workflow name is part of the group on purpose.
+#
+# A release reaches this workflow twice over: once from the push to master, and
+# once as the gate release.yml calls. Both runs carry the *same* github.ref
+# (refs/heads/master), so a group keyed on the ref alone put them in one bucket
+# and cancel-in-progress killed one of them — usually visible as jobs that start
+# and immediately go grey, and at worst as a release whose gate was cancelled
+# out from under it.
+#
+# For a reusable workflow, github.workflow is the *calling* workflow's name, so
+# the gate run lands in `ci-Chart Release-...` while the push run stays in
+# `ci-CI-...`. Superseding still works where it should: a second push to the
+# same branch cancels the first.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -62,6 +83,11 @@ jobs:
   build:
     name: Cross-compile
     needs: [lint, check]
+    # `inputs` is empty on the push/PR path, and !null is true there — so this
+    # runs by default and is skipped only when a caller explicitly opts out.
+    # Do not rewrite as `inputs.skip-cross-compile == false`: GitHub coerces
+    # both null and false to 0, so that form would skip the job on every push.
+    if: ${{ !inputs.skip-cross-compile }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,29 +7,52 @@ name: Release
 # to the default branch at the end, since the digest cannot be known until the
 # binary is built.
 #
-# Two entry points:
+# Two entry points, both of which pass the tag explicitly:
 #   - workflow_call from chart-release.yml, which is the normal path: a chart
 #     version bump creates the tag and calls this with `version`.
-#   - a manually pushed `v*` tag, kept as an escape hatch for re-releasing.
+#   - workflow_dispatch, the escape hatch for re-releasing an existing tag.
+#
+# There is deliberately no `push: tags` trigger. It could never fire on the
+# normal path anyway — a tag pushed with the default GITHUB_TOKEN does not
+# start workflow runs — so it was an escape hatch that only worked for someone
+# pushing tags with a PAT, while adding a second way for a release to start
+# and disagree with what the chart claims to be. The chart version stays the
+# single source of truth.
 on:
-  push:
-    tags: ["v*"]
   workflow_call:
     inputs:
       version:
         description: Tag to release, e.g. v0.1.3. Must already exist.
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Tag to re-release, e.g. v0.1.3. Must already exist.
+        required: true
+        type: string
 
 permissions:
   contents: write
+
+# A release ends by pushing the checksum commit to the default branch. Two
+# releases running at once would race there, and the loser would die on a
+# non-fast-forward push — having already published its binaries, leaving a
+# release whose chart points at the wrong digest. Queue them instead, and never
+# cancel: a half-finished release is worse than a slow one.
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
 
 jobs:
   # Reuse the CI pipeline as a gate; releases cannot ship if lint or tests
   # are red.
   ci:
-    needs: []
     uses: ./.github/workflows/ci.yml
+    with:
+      # goreleaser cross-compiles every target in the next job, so having CI
+      # do it first only adds minutes to the release.
+      skip-cross-compile: true
 
   release:
     needs: ci
@@ -38,11 +61,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # goreleaser needs full history for changelog
-          # When called from chart-release.yml the default ref is the branch the
-          # push landed on, not the new tag. Check the tag out explicitly so
-          # goreleaser derives the right version. `inputs.version` is empty on
-          # the tag-push path, where the default ref is already correct.
-          ref: ${{ inputs.version != '' && inputs.version || github.ref }}
+          # The default ref is the branch the caller's push landed on, not the
+          # new tag. Check the tag out explicitly so goreleaser derives the
+          # right version.
+          ref: ${{ inputs.version }}
 
       - uses: actions/setup-go@v5
         with:
@@ -99,9 +121,9 @@ jobs:
         shell: bash
         run: |
           set -eu
-          # On the workflow_call path GITHUB_REF_NAME is the *branch* the chart
-          # bump landed on, not the tag, so the input wins when present.
-          VERSION="${{ inputs.version != '' && inputs.version || github.ref_name }}"
+          # GITHUB_REF_NAME is the *branch* the chart bump landed on, not the
+          # tag, so the tag can only come from the input.
+          VERSION="${{ inputs.version }}"
           case "$VERSION" in
             v*) ;;
             *) echo "::error::resolved version '$VERSION' is not a v-prefixed tag"; exit 1 ;;

--- a/docs/development.md
+++ b/docs/development.md
@@ -89,16 +89,34 @@ push if they drift.
 4. Commits the new binary's SHA-256 back into `deploy/chart/values.yaml`, since
    the digest cannot exist until the binary is built.
 
-Two details that are load-bearing, in case you edit these workflows:
+To re-release an existing tag, run **Actions → Release → Run workflow** and
+give it the tag. That is the only other way in: `release.yml` has no tag-push
+trigger, because a tag pushed with the default `GITHUB_TOKEN` does not start
+workflow runs, so that path could never fire on the normal route anyway.
 
-- `release.yml` is invoked with `workflow_call`, **not** by its tag trigger. A
-  tag pushed using the default `GITHUB_TOKEN` does not start new workflow runs,
-  so the tag-triggered path would silently never fire. It is kept as a manual
-  escape hatch for re-releasing an existing tag.
+Four details that are load-bearing, in case you edit these workflows:
+
 - `chart-release.yml` watches **`Chart.yaml` only**, and the checksum commit
   writes **`values.yaml` only**. That asymmetry is what stops the release from
   re-triggering itself. Widening the path filter to `deploy/chart/**` creates an
   infinite release loop.
+- **`ci.yml`'s concurrency group includes `github.workflow`.** A release reaches
+  CI twice — once from the push to `master`, once as the gate `release.yml`
+  calls — and both runs carry the same `github.ref`. Keying the group on the ref
+  alone put them in one bucket, so `cancel-in-progress` killed one of them: jobs
+  that start and immediately go grey, and occasionally a release whose own gate
+  was cancelled. For a reusable workflow `github.workflow` is the *caller's*
+  name, which separates the two.
+- **The release gate skips the cross-compile job** (`skip-cross-compile: true`).
+  goreleaser rebuilds every target moments later, so running `make dist` first
+  only lengthened the release. The `if:` on that job is written as
+  `${{ !inputs.skip-cross-compile }}` rather than `== false` on purpose:
+  GitHub coerces both `null` and `false` to `0`, so the equality form would
+  skip the job on every ordinary push.
+- **`release.yml` serialises on one concurrency group and never cancels.** It
+  ends by pushing the checksum commit to the default branch; two releases at
+  once would race there, and the loser would fail the push having already
+  published its binaries.
 
 Between the version bump and the checksum commit there is a short window where
 the chart on `master` claims a new version but still carries the previous


### PR DESCRIPTION
A release pushed to master started CI twice — once from the push, once as the gate release.yml calls — and both runs carry the same github.ref. The concurrency group was keyed on the ref alone, so cancel-in-progress put them in one bucket and killed one: jobs that start and immediately go grey, and occasionally a release whose own gate was cancelled out from under it.

The group now includes github.workflow, which for a reusable workflow is the caller's name, so the gate and the push run no longer collide. Superseding still works where it should — a second push to a branch cancels the first.

Also on the release path:

- The gate skips the cross-compile job. goreleaser rebuilds every target moments later, so `make dist` there was duplicate work on the critical path.
- release.yml serialises on one concurrency group and never cancels: it ends by pushing the checksum commit to the default branch, and two releases at once would race there, the loser failing that push having already published its binaries.
- Dropped the `push: tags` trigger for workflow_dispatch. It could never fire on the normal path (a tag pushed with GITHUB_TOKEN starts no runs), so it was an escape hatch that only worked via a PAT while giving a release a second way to start; dispatch is the real one.