### PR TITLE
feat(release): record the checksum on dev for prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,8 @@ jobs:
           # need the deploy-key bypass on the protected branches.
           ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
-      # Fail now rather than after the binaries are published. Prereleases skip
-      # the writeback, so they do not need the key.
+      # Fail now rather than after the binaries are published.
       - name: Check release credentials
-        if: ${{ !inputs.prerelease }}
         env:
           RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
         run: |
@@ -203,12 +201,14 @@ jobs:
       # This writes values.yaml only. chart-release.yml watches Chart.yaml only.
       # That asymmetry is what makes the loop impossible — keep it.
       - name: Record checksum in chart values
-        if: ${{ !inputs.prerelease }}
         shell: bash
         env:
           VERSION: ${{ steps.crd.outputs.version }}
           SHA256: ${{ steps.crd.outputs.sha }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          # Prereleases record onto dev so the chart there can be installed with
+          # --set nodeDriver.version=<tag>; stable releases record onto the
+          # branch that serves the Rancher git-backed repository.
+          TARGET: ${{ inputs.prerelease && 'dev' || github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           VALUES=deploy/chart/values.yaml
@@ -216,13 +216,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # The build ran against a detached tag; move to the branch that serves
-          # the Rancher git-backed repository.
-          git fetch --depth=1 origin "$DEFAULT_BRANCH"
-          git checkout -B "$DEFAULT_BRANCH" "origin/$DEFAULT_BRANCH"
+          # The build ran against a detached tag; move to the target branch.
+          git fetch --depth=1 origin "$TARGET"
+          git checkout -B "$TARGET" "origin/$TARGET"
 
           if [ ! -f "$VALUES" ]; then
-            echo "::warning::$VALUES not present on $DEFAULT_BRANCH; skipping"; exit 0
+            echo "::warning::$VALUES not present on $TARGET; skipping"; exit 0
           fi
 
           # Edited with sed rather than `yq -i` on purpose: yq round-trips the
@@ -247,7 +246,7 @@ jobs:
           # [skip ci] keeps this from re-running the CI workflow; the path filter
           # in chart-release.yml already prevents a release loop.
           git commit -m "chore(chart): record ${VERSION} binary checksum [skip ci]"
-          git push origin "HEAD:$DEFAULT_BRANCH"
+          git push origin "HEAD:$TARGET"
 
       # Bring the checksum commit into dev: fast-forward if dev has nothing of
       # its own, otherwise merge. Warns instead of failing.

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -12,8 +12,8 @@ apiVersion: v2
 name: pve-rancher-driver
 description: Registers the Proxmox VE node driver with Rancher so RKE2/K3s machine pools can provision PVE virtual machines
 type: application
-version: "0.7.1"
-appVersion: "0.7.1"
+version: "0.7.2"
+appVersion: "0.7.2"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/lore09/pve-rancher-driver
 sources:

--- a/deploy/nodedriver.yaml
+++ b/deploy/nodedriver.yaml
@@ -29,7 +29,8 @@ metadata:
     privateCredentialFields: "apiTokenSecret"
     passwordFields: "apiTokenSecret"
 spec:
-  displayName: "Proxmox VE (pve)"
+  # Must equal metadata.name: Rancher derives the provider id from this.
+  displayName: "pve"
   description: "Provision RKE2/K3s nodes as Proxmox VE virtual machines cloned from a template"
   active: true
   addCloudCredential: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -128,9 +128,9 @@ The branch decides what kind of release you get:
 3. Calls [`release.yml`](../.github/workflows/release.yml), which runs CI as a
    gate, builds the binaries with goreleaser, renders
    `nodedriver-<version>.yaml`, and publishes the GitHub release.
-4. **On `master` only**, commits the new binary's SHA-256 back into
-   `deploy/chart/values.yaml`, since the digest cannot exist until the binary is
-   built, then fast-forwards `dev` onto that commit.
+4. Commits the new binary's SHA-256 into `deploy/chart/values.yaml` — onto
+   `dev` for a prerelease, onto `master` for a stable release, which then also
+   merges `master` back into `dev`.
 
 ### Cutting a dev build
 
@@ -143,12 +143,15 @@ Install a dev build with the attached manifest, not with Helm:
 kubectl apply -f nodedriver-v0.8.0-dev.yaml
 ```
 
-**The chart is not installable from `dev`.** `values.yaml` there still carries
-the last *stable* release's digest, and the chart deliberately refuses to render
-against a mismatched checksum rather than leaving a driver stuck in
-`Downloading`. That is also why step 4 above is skipped for prereleases: writing
-`checksumFor: v0.8.0-dev` against a chart declaring `0.8.0` would trip that same
-guard. Helm installs come from `master`.
+Or install the chart from `dev`, naming the dev version explicitly:
+
+```bash
+helm install pve-rancher-driver ./deploy/chart --set nodeDriver.version=v0.8.0-dev
+```
+
+The prerelease records its digest into `values.yaml` on `dev`, so the checksum
+is already correct. Without that `--set` the chart refuses to render, because
+its `appVersion` claims `0.8.0` and no such release exists yet.
 
 ### Promoting to stable
 


### PR DESCRIPTION
Prereleases now write their digest into values.yaml on dev, so the chart
there installs with --set nodeDriver.version=<tag>. The credentials check
no longer skips prereleases, since they push too.

Also fixes the NodeDriver manifest's displayName, which must equal
metadata.name or Rancher derives the wrong provider id.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
