### PR TITLE
Feat: Add support for --pve-cicustom and --pve-extra-config flags

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -12,8 +12,8 @@ apiVersion: v2
 name: pve-rancher-driver
 description: Registers the Proxmox VE node driver with Rancher so RKE2/K3s machine pools can provision PVE virtual machines
 type: application
-version: "0.7.2"
-appVersion: "0.7.2"
+version: "0.8.0"
+appVersion: "0.8.0"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/lore09/pve-rancher-driver
 sources:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -39,12 +39,12 @@ nodeDriver:
   # Written automatically by .github/workflows/release.yml after it builds the
   # release, because the digest cannot be known until the binary exists. Do not
   # edit by hand.
-  checksum: "6e32f37e57a57b89fb5a30ff8a7bad6aae9e0ae189bddb3330416ee851b729de"
+  checksum: "741eaac23251d6d69b29aa02b17bfb834fd31d658dd3d9586f9149043b359146"
   # The driver version `checksum` was recorded for. The chart refuses to render
   # when this disagrees with the version being deployed, which turns a silent
   # checksum mismatch (the classic "driver stuck in Downloading forever") into
   # an explicit error. Written automatically alongside `checksum`.
-  checksumFor: "v0.7.2"
+  checksumFor: "v0.8.0-dev"
 
   active: true
   addCloudCredential: true

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -325,6 +325,7 @@ hand the machine back immediately.
 | `pve-sshkeys` | *(empty)* | Extra OpenSSH public keys, one per line. The machine's own generated key is always injected as well |
 | `pve-ssh-user` | `root` | Account the driver and Rancher log in as. **Must be a user that exists in the guest** — `debian` for Debian's cloud image, `rancher` for Leap Micro. The `root` default works with neither |
 | `pve-ssh-port` | `22` | SSH port |
+| `pve-cicustom` | *(empty)* | PVE `cicustom` value naming cloud-init snippets, e.g. `vendor=local:snippets/rancher.yaml`. See below |
 
 `pve-ciuser` and `pve-ssh-user` are the same account: cloud-init installs the SSH
 keys for `ciuser`, and that is the only account anything can subsequently log
@@ -397,6 +398,95 @@ exceeds it.
 DNS (`pve-nameservers`, `pve-searchdomain`) requires `pve-cloudinit` in either
 mode, because PVE applies `nameserver`/`searchdomain` as cloud-init options and
 would otherwise drop them silently.
+
+### `pve-cicustom`
+
+Everything above configures cloud-init through the fields PVE exposes. That
+covers identity, addressing and DNS, and nothing else: adding a package,
+trusting a private registry's CA, or setting a sysctl means rebuilding the
+template. `pve-cicustom` points PVE at a snippet file instead, so the same
+template can be shared by pools that need different guest configuration.
+
+The value is PVE's own `cicustom` property string — comma-separated
+`<type>=<volume>` pairs — and the volume must live on a storage with the
+**`snippets`** content type enabled:
+
+```
+--pve-cicustom vendor=local:snippets/rancher.yaml
+--pve-cicustom vendor=local:snippets/rancher.yaml,meta=local:snippets/meta.yaml
+```
+
+Upload the file yourself, once, to `/var/lib/vz/snippets/` on the PVE node (or
+through **Datacenter → Storage → *storage* → Snippets** in the UI). The driver
+only references it.
+
+**Use `vendor=`, not `user=`.** They are not interchangeable:
+
+| Type | Behaviour |
+|---|---|
+| `vendor` | PVE generates no vendor-data of its own, so yours is **merged** with the generated user-data. This is the one to use |
+| `meta` | Replaces the generated meta-data. Rarely needed |
+| `network` | Replaces the network config PVE renders from `ipconfig0`. **Rejected** with `pve-ip-mode=static`, which is exactly that config; allowed under `dhcp` |
+| `user` | **Rejected.** It replaces the generated user-data entirely, and that is the only thing carrying `ciuser` and the SSH key. The key is generated per machine, so no snippet written in advance can contain it, and the node would boot with nobody able to log in |
+
+A `users:` directive in your snippet will not run. Cloud-init's `users` module
+runs once per instance and PVE's generated user-data has already used it to
+create `pve-ciuser`. Create accounts with `runcmd` instead, or add keys to the
+existing user with `pve-sshkeys`.
+
+Every machine reads the snippet as it boots, so it has to be there. A missing
+file, or a storage the machine's node cannot reach, produces a guest that never
+finishes configuring. Unless the storage is shared, put the snippet on every
+node in `pve-allowed-nodes`.
+
+The API token needs no privilege beyond the ones
+[rancher-setup.md](rancher-setup.md#restricting-the-token-to-a-resource-pool)
+already grants.
+
+## Additional PVE options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `pve-extra-config` | *(empty)* | Raw PVE VM config `key=value`; **repeatable**. See below |
+
+`pve-extra-config` sets a PVE config key directly, for the options this driver
+has no flag of its own for. Keys are applied after the VM is cloned and before
+it is started, so options that only take effect at boot still apply:
+
+```
+--pve-extra-config cpu=host
+--pve-extra-config numa=1
+--pve-extra-config balloon=0
+--pve-extra-config hostpci0=0000:01:00,pcie=1
+--pve-extra-config startup=order=1,up=30
+```
+
+The full key list is `man qm.conf`, or the PVE API docs for
+`PUT /nodes/{node}/qemu/{vmid}/config` — this driver does not interpret the
+value, it forwards it.
+
+Each occurrence is **one** key, split on its first `=` only. That is what lets
+values contain commas and further `=` signs (`hostpci0` and `startup` above),
+which most PVE property strings do.
+
+**Keys the driver sets itself are rejected**, naming the flag to use instead:
+`name`, `cores`, `sockets`, `memory`, `onboot`, `tags`, `description`,
+`ipconfig0`, `nameserver`, `searchdomain`, `ciuser`, `sshkeys` and `cicustom`.
+`agent` is rejected outright — IP discovery goes through the QEMU guest agent,
+so the driver enables it on every machine.
+
+Three more are rejected only while the flag that owns them is in use, and are
+otherwise yours to set here:
+
+| Key | Reserved while |
+|---|---|
+| The NIC named by `pve-net-device` | `pve-net-bridge` is set. With no bridge, `net0=...` here is a valid way to define the NIC |
+| The device named by `pve-boot-disk-device` | `pve-boot-disk-size` is growing it |
+| A `scsi<N>` slot | A `pve-data-disk` pins it with `device=`. Data disks without one take the next free slot, so they move out of the way of a slot set here |
+
+Values are not validated — this driver forwards them. A key PVE does not
+recognise, or a value it rejects, fails provisioning and the machine is removed;
+the PVE error naming the key appears in the machine's provisioning log.
 
 ## Debugging
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -123,6 +123,9 @@ type Driver struct {
 	SearchDomain     string
 	CIUser           string
 	SSHKeys          string
+	CICustom         string
+	ExtraConfigEntry []string
+	ExtraConfig      []proxmox.ConfigOption
 	Onboot           bool
 	AgentTimeout     time.Duration
 	CloudInitTimeout time.Duration
@@ -413,6 +416,16 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "PVE_SSHKEYS",
 			Usage:  "Extra OpenSSH public keys injected via cloud-init (one per line, plain text). The driver's own generated key is always added",
 		},
+		mcnflag.StringFlag{
+			Name:   "pve-cicustom",
+			EnvVar: "PVE_CICUSTOM",
+			Usage:  "PVE cicustom value naming cloud-init snippets, e.g. vendor=local:snippets/rancher.yaml. Use vendor= to add packages, certificates or sysctls without rebuilding the template; user= is rejected because it would replace the generated user-data carrying the driver's per-machine SSH key",
+		},
+		mcnflag.StringSliceFlag{
+			Name:   "pve-extra-config",
+			EnvVar: "PVE_EXTRA_CONFIG",
+			Usage:  "Raw PVE VM config key=value applied after every other setting, repeatable, e.g. cpu=host or hostpci0=0000:01:00,pcie=1. Escape hatch for PVE options this driver has no flag for; keys the driver writes itself are rejected",
+		},
 		mcnflag.BoolFlag{
 			Name:   "pve-onboot",
 			EnvVar: "PVE_ONBOOT",
@@ -516,6 +529,8 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	d.SearchDomain = strings.TrimSpace(flags.String("pve-searchdomain"))
 	d.CIUser = flags.String("pve-ciuser")
 	d.SSHKeys = flags.String("pve-sshkeys")
+	d.CICustom = strings.TrimSpace(flags.String("pve-cicustom"))
+	d.ExtraConfigEntry = flags.StringSlice("pve-extra-config")
 	d.Onboot = flags.Bool("pve-onboot")
 	d.SkipPermCheck = flags.Bool("pve-skip-permission-check")
 	d.KeepOnFailure = flags.Bool("pve-keep-on-failure")
@@ -633,6 +648,18 @@ func (d *Driver) PreCreateCheck() error {
 			return fmt.Errorf("pve: %s require --pve-net-bridge to be set", strings.Join(orphans, ", "))
 		}
 	}
+	mode, err := parseIPMode(d.IPMode)
+	if err != nil {
+		return err
+	}
+	if err := validateCICustom(d.CICustom, mode == ipModeStatic); err != nil {
+		return err
+	}
+	extra, err := ParseExtraConfig(d.ExtraConfigEntry, d.reservedConfigKeys())
+	if err != nil {
+		return err
+	}
+	d.ExtraConfig = extra
 	if err := d.init(); err != nil {
 		return err
 	}
@@ -642,6 +669,59 @@ func (d *Driver) PreCreateCheck() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	return d.client.VerifyPermissions(ctx)
+}
+
+// reservedConfigKeys are the PVE config keys this driver writes itself, mapped
+// to the flag that owns each one so a rejected --pve-extra-config entry names
+// the field to edit instead.
+//
+// Only keys actually written for *this* configuration are listed: with no
+// bridge named the NIC is left alone and net0 is fair game, and without a boot
+// disk resize nothing touches the boot device. Reserving them unconditionally
+// would refuse entries that are perfectly safe.
+func (d *Driver) reservedConfigKeys() map[string]string {
+	reserved := map[string]string{
+		// Not tied to a flag: IP discovery goes through the guest agent on
+		// every path, so the driver forces the channel on regardless.
+		"agent":       "the driver itself (guest agent is required for IP discovery)",
+		"name":        "--pve-vm-name-prefix",
+		"cores":       "--pve-cores",
+		"sockets":     "--pve-sockets",
+		"memory":      "--pve-memory",
+		"onboot":      "--pve-onboot",
+		"tags":        "--pve-tags",
+		"description": "--pve-description",
+	}
+	if d.CloudInit {
+		reserved["ipconfig0"] = "--pve-ip-mode"
+		reserved["nameserver"] = "--pve-nameservers"
+		reserved["searchdomain"] = "--pve-searchdomain"
+		reserved["ciuser"] = "--pve-ciuser"
+		reserved["sshkeys"] = "--pve-sshkeys"
+		reserved["cicustom"] = "--pve-cicustom"
+	}
+	// The MAC that pins IP discovery is read back off this device after
+	// Configure, so an override here would send the driver looking for an
+	// address on a NIC that no longer exists.
+	if d.NetBridge != "" {
+		device := strings.ToLower(strings.TrimSpace(d.NetDevice))
+		if device == "" {
+			device = "net0"
+		}
+		reserved[device] = "--pve-net-bridge"
+	}
+	if d.BootDiskGB > 0 {
+		reserved[strings.ToLower(d.BootDiskDevice)] = "--pve-boot-disk-size"
+	}
+	// Data disks with no explicit device= are assigned a free slot by scanning
+	// the live config, which already sees anything set here — only the pinned
+	// ones can collide.
+	for _, disk := range d.DataDisks {
+		if disk.Device != "" {
+			reserved[strings.ToLower(disk.Device)] = "--pve-data-disk device=" + disk.Device
+		}
+	}
+	return reserved
 }
 
 func (d *Driver) init() error {
@@ -768,6 +848,8 @@ func (d *Driver) finalizeCreate(ctx context.Context, vmName string) error {
 		NetVlanTag:   d.NetVlanTag,
 		NetMTU:       d.NetMTU,
 		NetFirewall:  firewall,
+		CICustom:     d.CICustom,
+		Extra:        d.ExtraConfig,
 	}
 	opts.CIUser = d.resolveCIUser()
 	if d.CloudInit {
@@ -786,6 +868,12 @@ func (d *Driver) finalizeCreate(ctx context.Context, vmName string) error {
 	}
 	if ipConfig != "ip=dhcp" {
 		log.Infof("pve: VM %d configured with static %s", d.VMID, ipConfig)
+	}
+	if d.CICustom != "" {
+		log.Infof("pve: VM %d takes cloud-init from %s (--pve-cicustom)", d.VMID, d.CICustom)
+	}
+	for _, extra := range d.ExtraConfig {
+		log.Infof("pve: VM %d set %s=%s (--pve-extra-config)", d.VMID, extra.Key, extra.Value)
 	}
 
 	// Grow the boot disk before AddDisks: slot allocation scans the live config

--- a/pkg/driver/extraconfig.go
+++ b/pkg/driver/extraconfig.go
@@ -1,0 +1,142 @@
+package driver
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/lore09/pve-rancher-driver/pkg/proxmox"
+)
+
+// extraConfigKeyPattern is the shape of a PVE VM config key: lowercase, and
+// possibly ending in an index (hostpci0, tpmstate0). Validating it here turns a
+// typo into a message naming the flag rather than a 400 from the PVE API
+// halfway through Create, with the VM already cloned.
+var extraConfigKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// ParseExtraConfig turns the --pve-extra-config occurrences into ordered PVE
+// config options.
+//
+// One occurrence is one option, split on its *first* `=` only: PVE config
+// values are themselves comma- and equals-separated lists (`startup=order=1,up=30`,
+// `hostpci0=0000:01:00,pcie=1`), so anything cleverer would have to re-implement
+// PVE's own property-string grammar to hand it straight back.
+//
+// reserved maps a key the driver writes itself to the flag that owns it. Those
+// are rejected rather than overwritten: the driver reads several of them back
+// (the NIC's MAC pins IP discovery, the boot disk device is what gets resized)
+// and a silent override would surface much later as a node that never reports
+// an address.
+func ParseExtraConfig(entries []string, reserved map[string]string) ([]proxmox.ConfigOption, error) {
+	opts := make([]proxmox.ConfigOption, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
+
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		idx := strings.Index(entry, "=")
+		if idx <= 0 {
+			return nil, fmt.Errorf("pve: --pve-extra-config %q is not a key=value pair, e.g. cpu=host", entry)
+		}
+		key := strings.ToLower(strings.TrimSpace(entry[:idx]))
+		value := strings.TrimSpace(entry[idx+1:])
+
+		if !extraConfigKeyPattern.MatchString(key) {
+			return nil, fmt.Errorf("pve: --pve-extra-config key %q is not a valid PVE config key; use lowercase letters, digits and underscores, e.g. cpu, numa, hostpci0", key)
+		}
+		if value == "" {
+			return nil, fmt.Errorf("pve: --pve-extra-config %q has an empty value; PVE has no way to express \"unset\" here, so drop the entry instead", key)
+		}
+		if strings.ContainsAny(value, "\r\n") {
+			return nil, fmt.Errorf("pve: --pve-extra-config %q value must be a single line", key)
+		}
+		if owner, taken := reserved[key]; taken {
+			return nil, fmt.Errorf("pve: --pve-extra-config cannot set %q; the driver writes that key itself from %s, and overriding it here would be silently undone or would break the driver's own use of it", key, owner)
+		}
+		if seen[key] {
+			return nil, fmt.Errorf("pve: --pve-extra-config sets %q more than once; PVE keeps one value per key, so only the last would apply", key)
+		}
+		seen[key] = true
+
+		opts = append(opts, proxmox.ConfigOption{Key: key, Value: value})
+	}
+
+	return opts, nil
+}
+
+// ciCustomVolumePattern matches the `storage:snippets/file` volume id PVE
+// expects. The `snippets/` segment is not a convention: cicustom only accepts a
+// volume on a storage with the `snippets` content type enabled, so a path
+// without it fails at create time.
+var ciCustomVolumePattern = regexp.MustCompile(`^[A-Za-z0-9._-]+:snippets/[A-Za-z0-9._/-]+$`)
+
+// ciCustomTypes are the four cloud-init parts PVE can source from a snippet.
+var ciCustomTypes = map[string]bool{"meta": true, "network": true, "user": true, "vendor": true}
+
+// validateCICustom checks --pve-cicustom before anything is cloned.
+//
+// staticIP reports whether the driver is generating ipconfig0 itself, which a
+// `network=` snippet would replace.
+func validateCICustom(raw string, staticIP bool) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	seen := map[string]bool{}
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		typ, volume, ok := strings.Cut(part, "=")
+		typ = strings.ToLower(strings.TrimSpace(typ))
+		volume = strings.TrimSpace(volume)
+		if !ok || volume == "" {
+			return fmt.Errorf("pve: --pve-cicustom %q is not a <type>=<volume> pair, e.g. vendor=local:snippets/rancher.yaml", part)
+		}
+		if !ciCustomTypes[typ] {
+			return fmt.Errorf("pve: --pve-cicustom type %q is not one of %s", typ, strings.Join(sortedCICustomTypes(), ", "))
+		}
+		if seen[typ] {
+			return fmt.Errorf("pve: --pve-cicustom sets %q twice; PVE takes one snippet per type", typ)
+		}
+		seen[typ] = true
+
+		if !ciCustomVolumePattern.MatchString(volume) {
+			return fmt.Errorf("pve: --pve-cicustom volume %q must be <storage>:snippets/<file>, e.g. local:snippets/rancher.yaml — cicustom only reads from a storage with the `snippets` content type enabled", volume)
+		}
+	}
+
+	// PVE generates user-data *or* takes yours, never both: a `user=` snippet
+	// replaces the generated one wholesale, and the generated one is what
+	// carries ciuser and sshkeys. Those keys are minted per machine at create
+	// time, so a snippet written in advance cannot contain them — the node
+	// would come up with nobody able to log in, and the driver could not even
+	// format its data disks. `vendor=` is the channel that merges instead.
+	if seen["user"] {
+		return fmt.Errorf("pve: --pve-cicustom user=... replaces the cloud-init user-data PVE generates, which is the only thing carrying the SSH key the driver and Rancher log in with — and that key is generated per machine, so no pre-written snippet can contain it. Use vendor=... instead: PVE generates no vendor-data, so yours is merged rather than substituted")
+	}
+
+	// ipconfig0 and a network snippet are the same slot. In DHCP mode the
+	// driver writes nothing worth protecting, so a network snippet is a
+	// legitimate way to configure something ipconfig0 cannot express.
+	if seen["network"] && staticIP {
+		return fmt.Errorf("pve: --pve-cicustom network=... replaces the network config PVE renders from ipconfig0, which is how --pve-ip-mode=static assigns each machine its address; the two cannot both apply. Drop the network snippet, or switch --pve-ip-mode to dhcp and let the snippet own addressing")
+	}
+
+	return nil
+}
+
+func sortedCICustomTypes() []string {
+	out := make([]string, 0, len(ciCustomTypes))
+	for t := range ciCustomTypes {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/driver/extraconfig_test.go
+++ b/pkg/driver/extraconfig_test.go
@@ -1,0 +1,125 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lore09/pve-rancher-driver/pkg/proxmox"
+)
+
+func TestParseExtraConfig(t *testing.T) {
+	reserved := map[string]string{"cores": "--pve-cores"}
+
+	t.Run("keeps order and splits on the first equals only", func(t *testing.T) {
+		got, err := ParseExtraConfig([]string{
+			"cpu=host",
+			"  ",
+			"hostpci0=0000:01:00,pcie=1",
+			"startup=order=1,up=30",
+		}, reserved)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []proxmox.ConfigOption{
+			{Key: "cpu", Value: "host"},
+			{Key: "hostpci0", Value: "0000:01:00,pcie=1"},
+			{Key: "startup", Value: "order=1,up=30"},
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d options, want %d: %+v", len(got), len(want), got)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("option %d = %+v, want %+v", i, got[i], want[i])
+			}
+		}
+	})
+
+	for name, tc := range map[string]struct {
+		entry string
+		want  string
+	}{
+		"no equals":       {"cpuhost", "not a key=value pair"},
+		"empty key":       {"=host", "not a key=value pair"},
+		"bad key":         {"CPU-Type=host", "not a valid PVE config key"},
+		"empty value":     {"cpu=", "empty value"},
+		"reserved key":    {"cores=8", "the driver writes that key itself from --pve-cores"},
+		"newline injects": {"args=-a\n-b", "single line"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseExtraConfig([]string{tc.entry}, reserved)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("got %v, want an error containing %q", err, tc.want)
+			}
+		})
+	}
+
+	t.Run("duplicate key", func(t *testing.T) {
+		_, err := ParseExtraConfig([]string{"cpu=host", "cpu=kvm64"}, reserved)
+		if err == nil || !strings.Contains(err.Error(), "more than once") {
+			t.Fatalf("got %v, want a duplicate-key error", err)
+		}
+	})
+}
+
+func TestReservedConfigKeys(t *testing.T) {
+	d := &Driver{BootDiskDevice: "scsi0"}
+
+	// Nothing is written to the NIC or the boot disk in this configuration, so
+	// setting them by hand is legitimate rather than a collision.
+	if _, taken := d.reservedConfigKeys()["net0"]; taken {
+		t.Error("net0 reserved without --pve-net-bridge")
+	}
+	if _, taken := d.reservedConfigKeys()["scsi0"]; taken {
+		t.Error("boot disk reserved without --pve-boot-disk-size")
+	}
+
+	d.NetBridge = "vmbr1"
+	d.NetDevice = "net1"
+	d.BootDiskGB = 40
+	d.CloudInit = true
+	d.DataDisks = []proxmox.DiskSpec{{Device: "scsi5"}, {}}
+
+	keys := d.reservedConfigKeys()
+	for _, key := range []string{"net1", "scsi0", "scsi5", "sshkeys", "cicustom", "agent"} {
+		if _, taken := keys[key]; !taken {
+			t.Errorf("%s should be reserved", key)
+		}
+	}
+	if _, taken := keys["net0"]; taken {
+		t.Error("net0 reserved while --pve-net-device is net1")
+	}
+}
+
+func TestValidateCICustom(t *testing.T) {
+	for name, tc := range map[string]struct {
+		raw      string
+		staticIP bool
+		want     string
+	}{
+		"empty":            {"", false, ""},
+		"vendor":           {"vendor=local:snippets/rancher.yaml", true, ""},
+		"vendor and meta":  {"vendor=local:snippets/a.yaml,meta=cephfs:snippets/b.yml", false, ""},
+		"network on dhcp":  {"network=local:snippets/net.yaml", false, ""},
+		"network onstatic": {"network=local:snippets/net.yaml", true, "--pve-ip-mode=static"},
+		"user rejected":    {"user=local:snippets/u.yaml", false, "Use vendor=... instead"},
+		"unknown type":     {"boot=local:snippets/u.yaml", false, "is not one of"},
+		"duplicate type":   {"vendor=local:snippets/a.yaml,vendor=local:snippets/b.yaml", false, "twice"},
+		"not a pair":       {"local:snippets/a.yaml", false, "not a <type>=<volume> pair"},
+		"missing snippets": {"vendor=local:rancher.yaml", false, "snippets/"},
+		"bare path":        {"vendor=/etc/rancher.yaml", false, "snippets/"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := validateCICustom(tc.raw, tc.staticIP)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("got %v, want an error containing %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/proxmox/client.go
+++ b/pkg/proxmox/client.go
@@ -510,6 +510,9 @@ func (c *Client) Configure(ctx context.Context, vmid int, opts VMOptions) error 
 		if opts.SSHKeys != "" {
 			options = append(options, proxmox.VirtualMachineOption{Name: "sshkeys", Value: opts.SSHKeys})
 		}
+		if opts.CICustom != "" {
+			options = append(options, proxmox.VirtualMachineOption{Name: "cicustom", Value: opts.CICustom})
+		}
 	}
 	// Rewriting net<N> without an explicit macaddr= makes PVE generate a fresh
 	// MAC for the device. That is safe here only because the driver captures
@@ -520,6 +523,9 @@ func (c *Client) Configure(ctx context.Context, vmid int, opts VMOptions) error 
 			Name:  netDeviceKey(opts.NetDevice),
 			Value: buildNetValue(opts),
 		})
+	}
+	for _, extra := range opts.Extra {
+		options = append(options, proxmox.VirtualMachineOption{Name: extra.Key, Value: extra.Value})
 	}
 	if len(options) == 0 {
 		return nil
@@ -938,6 +944,24 @@ type VMOptions struct {
 	// NetFirewall toggles the PVE firewall on the NIC; nil leaves it at the
 	// PVE default.
 	NetFirewall *bool
+
+	// CICustom is PVE's `cicustom` config value, naming snippets that supply
+	// cloud-init parts (`vendor=local:snippets/rancher.yaml`). Only applied
+	// with CloudInit set, since it is meaningless without the cloud-init drive.
+	CICustom string
+
+	// Extra are raw PVE config keys passed straight through from
+	// --pve-extra-config. They are applied last, but the caller has already
+	// rejected any key the fields above own, so the order is not load-bearing.
+	Extra []ConfigOption
+}
+
+// ConfigOption is one raw PVE VM config key/value. A slice rather than a map
+// because the order the operator wrote them in is the order they are applied,
+// which keeps a failing request readable against the flags that produced it.
+type ConfigOption struct {
+	Key   string
+	Value string
 }
 
 // ---------- PVE version + permission probe ----------


### PR DESCRIPTION
This pull request introduces support for advanced Proxmox VE (PVE) VM customization through two new driver flags: `--pve-cicustom` for cloud-init snippets and `--pve-extra-config` for arbitrary PVE VM configuration options. It also adds robust validation and error reporting for these features, updates documentation, and includes comprehensive unit tests.

**New Features:**

* Added support for the `--pve-cicustom` flag, allowing users to inject PVE cloud-init snippets for advanced guest customization without rebuilding templates. Includes validation to ensure only safe and compatible snippet types are used. [[1]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R419-R428) [[2]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R532-R533) [[3]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R651-R662) [[4]](diffhunk://#diff-c1d5e456c7b1c5632968b252a8854338d80584e8435295a01e9b08ac3b745f81R1-R142)
* Added support for the `--pve-extra-config` flag, enabling users to set arbitrary PVE VM config options not otherwise exposed by the driver. Includes validation to prevent collisions with driver-managed keys and to ensure correct syntax. [[1]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R419-R428) [[2]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R532-R533) [[3]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R651-R662) [[4]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R674-R726) [[5]](diffhunk://#diff-c1d5e456c7b1c5632968b252a8854338d80584e8435295a01e9b08ac3b745f81R1-R142)

**Validation and Error Handling:**

* Implemented comprehensive validation for both `--pve-cicustom` and `--pve-extra-config`, with clear error messages for invalid or unsafe usage. [[1]](diffhunk://#diff-c1d5e456c7b1c5632968b252a8854338d80584e8435295a01e9b08ac3b745f81R1-R142) [[2]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R651-R662) [[3]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R674-R726)

**Documentation Updates:**

* Updated `docs/flags.md` to document the new `pve-cicustom` and `pve-extra-config` flags, including usage examples, best practices, and caveats. [[1]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dR328) [[2]](diffhunk://#diff-3981efdc8e2553d38238838106f5859798b9f590e3d453779d7d9c56d7f0d14dR402-R490)

**Testing:**

* Added unit tests for the new parsing and validation logic in `extraconfig.go`, ensuring correct behavior and error reporting for a variety of input cases.

**Release and Chart Updates:**

* Bumped the chart and app version to `0.8.0` and updated the driver checksum for the new release. [[1]](diffhunk://#diff-41653ce465a9ddc0f2f70cb4689721a24b0db37a795befa4f251d1ceef3547cdL15-R16) [[2]](diffhunk://#diff-46ba93a79d17b3b2e6b5b957292c18110b19e37f46c2a66827688feb77ecd831L42-R47)

These changes provide significant flexibility for advanced PVE VM provisioning scenarios while maintaining safety and clear user guidance.