### PR TITLE
Feat: Add tri-state backup flag for boot disks in PVE backup jobs

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -12,8 +12,8 @@ apiVersion: v2
 name: pve-rancher-driver
 description: Registers the Proxmox VE node driver with Rancher so RKE2/K3s machine pools can provision PVE virtual machines
 type: application
-version: "0.8.0"
-appVersion: "0.8.0"
+version: "0.8.1"
+appVersion: "0.8.1"
 kubeVersion: ">=1.23.0-0"
 home: https://github.com/lore09/pve-rancher-driver
 sources:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -39,12 +39,12 @@ nodeDriver:
   # Written automatically by .github/workflows/release.yml after it builds the
   # release, because the digest cannot be known until the binary exists. Do not
   # edit by hand.
-  checksum: "1f4cf102f38cfebf1969dc7443036cd901ebef42605c3e27036a98d1fc29f88f"
+  checksum: "d83deccd2b5a6ccfd826f808cbdd566076eadfd7a94a83d163b1ffb3c74abc39"
   # The driver version `checksum` was recorded for. The chart refuses to render
   # when this disagrees with the version being deployed, which turns a silent
   # checksum mismatch (the classic "driver stuck in Downloading forever") into
   # an explicit error. Written automatically alongside `checksum`.
-  checksumFor: "v0.8.0"
+  checksumFor: "v0.8.1-dev"
 
   active: true
   addCloudCredential: true

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -200,8 +200,32 @@ storage that clone fails with a Proxmox-side error naming the mismatch.
 |------|---------|-------------|
 | `pve-boot-disk-size` | `0` | Grow the cloned boot disk to this size in GB (`0` = keep the template's size). PVE can only grow a disk, never shrink it |
 | `pve-boot-disk-device` | `scsi0` | PVE config key of the boot disk grown by `pve-boot-disk-size` (`scsi0`, `virtio0`, `sata0`, ...) |
+| `pve-backup` | *(empty)* | `true`/`false` to include the boot disk in PVE backups. Empty keeps whatever the template set. See below |
 | `pve-data-disk` | *(empty)* | Data disk to attach; **repeatable**. Grammar below |
 | `pve-disk-setup-timeout` | `300` | Seconds to wait for SSH plus formatting and mounting of the data disks |
+
+### `pve-backup`
+
+Whether a VM is picked up by a PVE backup job is a property of each of its
+disks, not of the VM. `pve-backup` sets it on the boot disk; data disks carry
+their own `backup=` key on `pve-data-disk`.
+
+| Value | Effect |
+|---|---|
+| *(empty)* | Leaves the setting the clone inherited from the template |
+| `true` | Includes the boot disk, whatever the template said |
+| `false` | Excludes it |
+
+Empty is not the same as `true`. A clone inherits the template's disk
+properties, so a template built with backups switched off produces nodes with
+backups off — `true` is how you override that rather than merely restate PVE's
+default.
+
+Worth deciding deliberately for a Kubernetes node. A worker's boot disk holds
+no unique state, and backing up every node in a pool multiplies backup storage
+by the node count for something a rebuild reproduces in minutes. Control-plane
+nodes carry etcd, but Rancher's own etcd snapshots are the supported way to
+recover those.
 
 ### `pve-data-disk` grammar
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -102,6 +102,7 @@ type Driver struct {
 	Sockets          int
 	MemoryMB         int
 	BootDiskGB       int
+	Backup           string
 	DataDiskEntries  []string
 	DataDisks        []proxmox.DiskSpec
 	DiskSetupTimeout time.Duration
@@ -296,6 +297,15 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			EnvVar: "PVE_BOOT_DISK_DEVICE",
 			Usage:  "PVE config key of the boot disk grown by pve-boot-disk-size, e.g. scsi0, virtio0, sata0",
 			Value:  defaultBootDiskDevice,
+		},
+		// Tri-state rather than a BoolFlag: an unset BoolFlag is
+		// indistinguishable from an explicit false, so a machine pool created
+		// before this flag existed would read as "exclude from backups" and
+		// silently drop every node out of the backup job.
+		mcnflag.StringFlag{
+			Name:   "pve-backup",
+			EnvVar: "PVE_BACKUP",
+			Usage:  "true/false to include the boot disk in PVE backups; empty keeps whatever the template set (PVE includes disks by default). Data disks have their own backup= key on pve-data-disk",
 		},
 		mcnflag.StringSliceFlag{
 			Name:   "pve-data-disk",
@@ -495,6 +505,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 	if d.BootDiskDevice == "" {
 		d.BootDiskDevice = defaultBootDiskDevice
 	}
+	d.Backup = strings.TrimSpace(flags.String("pve-backup"))
 	d.DataDiskEntries = flags.StringSlice("pve-data-disk")
 	d.NetIface = flags.String("pve-net-iface")
 	d.NetDevice = flags.String("pve-net-device")
@@ -630,6 +641,9 @@ func (d *Driver) PreCreateCheck() error {
 	if _, ferr := parseNetFirewall(d.NetFirewall); ferr != nil {
 		return ferr
 	}
+	if _, berr := parseTriState("--pve-backup", d.Backup); berr != nil {
+		return berr
+	}
 	// The pve-net-* knobs are only ever applied as part of rewriting the net
 	// device, which is gated on a bridge being named. Silently ignoring them
 	// would look like the driver honoured a VLAN it never set, so fail loudly.
@@ -712,6 +726,9 @@ func (d *Driver) reservedConfigKeys() map[string]string {
 	}
 	if d.BootDiskGB > 0 {
 		reserved[strings.ToLower(d.BootDiskDevice)] = "--pve-boot-disk-size"
+	}
+	if d.Backup != "" {
+		reserved[strings.ToLower(d.BootDiskDevice)] = "--pve-backup"
 	}
 	// Data disks with no explicit device= are assigned a free slot by scanning
 	// the live config, which already sees anything set here — only the pinned
@@ -884,6 +901,22 @@ func (d *Driver) finalizeCreate(ctx context.Context, vmName string) error {
 			return err
 		}
 		log.Infof("pve: grew boot disk %s of VM %d to %dGB", d.BootDiskDevice, d.VMID, d.BootDiskGB)
+	}
+
+	// After the resize, never before: the resize rewrites size= in the same
+	// property string this reads back and re-sends, so doing it first would put
+	// the pre-resize size back.
+	if backup, err := parseTriState("--pve-backup", d.Backup); err != nil {
+		return err
+	} else if backup != nil {
+		if err := d.client.SetBootDiskBackup(ctx, d.VMID, d.BootDiskDevice, *backup); err != nil {
+			return err
+		}
+		if *backup {
+			log.Infof("pve: boot disk %s of VM %d is included in PVE backups", d.BootDiskDevice, d.VMID)
+		} else {
+			log.Infof("pve: boot disk %s of VM %d is excluded from PVE backups (--pve-backup=false)", d.BootDiskDevice, d.VMID)
+		}
 	}
 
 	attached, err := d.client.AddDisks(ctx, d.VMID, d.DataDisks)
@@ -1156,6 +1189,13 @@ func (d *Driver) validateVMNamePrefix() error {
 // that third state, and defaulting to false would silently disable a firewall
 // the template had enabled.
 func parseNetFirewall(s string) (*bool, error) {
+	return parseTriState("--pve-net-firewall", s)
+}
+
+// parseTriState parses a flag whose three states are "leave PVE's own default
+// alone" (empty), true and false — which a plain BoolFlag cannot express, since
+// an unset one is indistinguishable from an explicit false.
+func parseTriState(flag, s string) (*bool, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "":
 		return nil, nil
@@ -1166,7 +1206,7 @@ func parseNetFirewall(s string) (*bool, error) {
 		v := false
 		return &v, nil
 	}
-	return nil, fmt.Errorf("pve: --pve-net-firewall must be true or false, got %q", s)
+	return nil, fmt.Errorf("pve: %s must be true or false, got %q", flag, s)
 }
 
 // ensureSSHKeyPair creates the docker-machine SSH keypair at GetSSHKeyPath()

--- a/pkg/proxmox/client.go
+++ b/pkg/proxmox/client.go
@@ -612,6 +612,76 @@ func (c *Client) ResizeBootDisk(ctx context.Context, vmid int, disk string, size
 	return nil
 }
 
+// setDiskProperty sets key=val on a PVE disk property string, replacing the
+// existing setting or appending one.
+//
+// The first element is the volume id ("local-lvm:vm-101-disk-0") and carries no
+// "=", so it is always kept as-is; only the key=value pairs after it are
+// candidates for replacement.
+func setDiskProperty(value, key, val string) string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts)+1)
+	replaced := false
+	for i, part := range parts {
+		if i > 0 && strings.HasPrefix(part, key+"=") {
+			out = append(out, key+"="+val)
+			replaced = true
+			continue
+		}
+		out = append(out, part)
+	}
+	if !replaced {
+		out = append(out, key+"="+val)
+	}
+	return strings.Join(out, ",")
+}
+
+// SetBootDiskBackup includes the given disk in PVE's backups, or excludes it.
+//
+// PVE has no way to set one property of a disk on its own: the whole property
+// string has to be rewritten, so it is read back first. Call this *after*
+// ResizeBootDisk — the resize rewrites size= in that same string, and writing a
+// value read before it would put the old size back.
+func (c *Client) SetBootDiskBackup(ctx context.Context, vmid int, disk string, backup bool) error {
+	if disk == "" {
+		return errors.New("proxmox: disk device is required to set its backup flag")
+	}
+	node, err := c.ResolveNode(ctx)
+	if err != nil {
+		return err
+	}
+	raw := map[string]interface{}{}
+	if err := c.api.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/config", node, vmid), &raw); err != nil {
+		return fmt.Errorf("proxmox: cannot read vm %d config: %w", vmid, err)
+	}
+	current, ok := raw[disk].(string)
+	if !ok || current == "" {
+		return fmt.Errorf("proxmox: vm %d has no disk %s to set the backup flag on; check --pve-boot-disk-device matches the template's boot disk", vmid, disk)
+	}
+	flag := "0"
+	if backup {
+		flag = "1"
+	}
+	updated := setDiskProperty(current, "backup", flag)
+	if updated == current {
+		return nil
+	}
+	vm, err := c.vm(ctx, vmid)
+	if err != nil {
+		return err
+	}
+	task, err := vm.Config(ctx, proxmox.VirtualMachineOption{Name: disk, Value: updated})
+	if err != nil {
+		return fmt.Errorf("proxmox: setting backup=%s on %s of vm %d failed: %w", flag, disk, vmid, err)
+	}
+	if task != nil {
+		if err := task.Wait(ctx, time.Second, c.waitTimeout()); err != nil {
+			return fmt.Errorf("proxmox: backup-flag task for vm %d did not complete: %w", vmid, err)
+		}
+	}
+	return nil
+}
+
 // buildDiskValue renders the PVE config value for one data disk. The key order
 // is fixed so the value is stable and diffable in tests and in PVE's UI.
 //

--- a/pkg/proxmox/client_test.go
+++ b/pkg/proxmox/client_test.go
@@ -413,3 +413,38 @@ func TestCloneOptionsDropStorageAndFormatForLinkedClones(t *testing.T) {
 		})
 	}
 }
+
+func TestSetDiskProperty(t *testing.T) {
+	for name, tc := range map[string]struct {
+		value, key, val, want string
+	}{
+		"appends when absent": {
+			"local-lvm:vm-101-disk-0,iothread=1,size=20G", "backup", "0",
+			"local-lvm:vm-101-disk-0,iothread=1,size=20G,backup=0",
+		},
+		"replaces in place, preserving order": {
+			"local-lvm:vm-101-disk-0,backup=1,size=20G", "backup", "0",
+			"local-lvm:vm-101-disk-0,backup=0,size=20G",
+		},
+		"volume id is never treated as a pair": {
+			"local-lvm:vm-101-disk-0", "backup", "1",
+			"local-lvm:vm-101-disk-0,backup=1",
+		},
+		// A volume id can itself contain the key as a substring; only a real
+		// key=value pair after the first element may be replaced.
+		"substring in the volume id is left alone": {
+			"backups:vm-101-disk-0,size=20G", "backup", "0",
+			"backups:vm-101-disk-0,size=20G,backup=0",
+		},
+		"no change when already correct": {
+			"local-lvm:vm-101-disk-0,backup=1", "backup", "1",
+			"local-lvm:vm-101-disk-0,backup=1",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := setDiskProperty(tc.value, tc.key, tc.val); got != tc.want {
+				t.Errorf("setDiskProperty(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request adds support for configuring whether the boot disk of a Proxmox VM should be included in Proxmox VE (PVE) backups, via a new `pve-backup` flag. This allows users to explicitly control backup inclusion for the boot disk, rather than inheriting the template's setting or relying on PVE's default. The implementation includes updates to documentation, the driver, and the Proxmox client, as well as associated tests.

**Major features and improvements:**

#### Boot Disk Backup Flag Support

* Added a new `pve-backup` flag (tri-state: unset, true, false) to the driver, allowing users to specify whether the boot disk should be included in PVE backups. This is exposed as a `--pve-backup` CLI flag and corresponding environment variable (`PVE_BACKUP`). [[1]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R105) [[2]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R301-R309) [[3]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R508) [[4]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R644-R646) [[5]](diffhunk://#diff-e8a7e777d80a14b455bdbf7aae3f28ad8082ffa0a06579e11cc1af741b5f98f7R730-R732)
* Implemented logic in the driver to apply the backup flag after resizing the boot disk, ensuring the correct order of operations and avoiding property overwrites.

#### Proxmox Client Enhancements

* Added `SetBootDiskBackup` to the Proxmox client, which updates the `backup` property on the boot disk in the VM configuration. This uses a new helper, `setDiskProperty`, to safely set or update key/value pairs in disk property strings.

#### Documentation Updates

* Updated `docs/flags.md` to document the new `pve-backup` flag, its behavior, and considerations for Kubernetes node backups.

#### Testing

* Added unit tests for the `setDiskProperty` helper to ensure correct property setting and replacement logic.

#### Versioning and Chart Updates

* Bumped chart and app version to `0.8.1` and updated the driver checksum in Helm chart files to reflect the new release. [[1]](diffhunk://#diff-41653ce465a9ddc0f2f70cb4689721a24b0db37a795befa4f251d1ceef3547cdL15-R16) [[2]](diffhunk://#diff-46ba93a79d17b3b2e6b5b957292c18110b19e37f46c2a66827688feb77ecd831L42-R47)

These changes provide users with fine-grained control over Proxmox VM backup behavior and improve the reliability and clarity of the backup configuration process.